### PR TITLE
Initial snippets for salt states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-
+.mypy_cache/

--- a/generate_snippets.py
+++ b/generate_snippets.py
@@ -17,11 +17,6 @@ def _gen_snippet(state_name, state_functions):
     Builds up and returns basic snippet definition for a given state
     '''
     snippets = {}
-    snippets['{} state'.format(state_name)] = {}
-    snippets['{} state'.format(state_name)]['prefix'] = ['{}.'.format(state_name)]
-    snippets['{} state'.format(state_name)]['body'] = ['{0}.${{1|{1}|}}:'.format(state_name, ','.join(state_functions))]
-    snippets['{} state'.format(state_name)]['description'] = "{} state".format(state_name)
-
     for function in state_functions:
         snippets['{}.{}'.format(state_name, function)] = {}
         snippets['{}.{}'.format(state_name, function)]['prefix'] = '{}.{}:'.format(state_name, function)

--- a/generate_snippets.py
+++ b/generate_snippets.py
@@ -1,0 +1,113 @@
+'''
+generate_snippets uses salt-call equivalent to list existing states and their functions.
+Basic autocomplete snippets are then configured for each state.
+If the snippet has been further edited, the script will not touch them. Thus,
+the resulting workflow is to run generate_snippets on new salt releases to
+capture any added states or functions. Then hand edit for the defaults which
+make sense.
+'''
+import salt.config
+import salt.loader
+
+import os
+import json
+
+def _gen_snippet(state_name, state_functions):
+    '''
+    Builds up and returns basic snippet definition for a given state
+    '''
+    snippets = {}
+    snippets['{} state'.format(state_name)] = {}
+    snippets['{} state'.format(state_name)]['prefix'] = ['{}.'.format(state_name)]
+    snippets['{} state'.format(state_name)]['body'] = ['{0}.${{1|{1}|}}:'.format(state_name, ','.join(state_functions))]
+    snippets['{} state'.format(state_name)]['description'] = "{} state".format(state_name)
+
+    for function in state_functions:
+        snippets['{}.{}'.format(state_name, function)] = {}
+        snippets['{}.{}'.format(state_name, function)]['prefix'] = '{}.{}:'.format(state_name, function)
+        snippets['{}.{}'.format(state_name, function)]['body'] = ['{}.{}:'.format(state_name, function), "$0"]
+        snippets['{}.{}'.format(state_name, function)]['description'] = '{}.{}:'.format(state_name, function)
+    return snippets
+
+def _get_state_name(json_path):
+    '''
+    Returns just the state name from a string like ./snippets/test.json
+    Used for sorting the snippet list in package.json
+    '''
+    state_name = json_path['path'][11:-5]
+    return state_name
+
+def _add_all_snippets(states):
+    '''
+    Ensures package.json is updated with all generated state snippet paths
+    '''
+    state_paths = list(map(lambda x : "./snippets/{}.json".format(x), states))
+    with open('package.json', 'r') as json_file:
+        data = json.load(json_file)
+    configured_snippets = []
+    snippet_data = data['contributes']['snippets']
+    for current_snippet in snippet_data:
+        current_path = current_snippet['path']
+        configured_snippets.append(current_path)
+    needed_snippets = list(set(state_paths).difference(set(configured_snippets)))
+    if needed_snippets:
+        for new_snippet_path in needed_snippets:
+            print('Adding support for {} completion'.format(new_snippet_path))
+            new_snippet = {}
+            new_snippet['language'] = 'sls'
+            new_snippet['path'] = new_snippet_path
+            data['contributes']['snippets'].append(new_snippet)
+        # Sort snippet data
+        snippet_data = data['contributes']['snippets']
+        snippet_data.sort(key=_get_state_name)
+        data['contributes']['snippets'] = snippet_data
+        with open('package.json', 'w') as json_file:
+            json.dump(data, json_file, indent='\t')
+    else:
+        print("All states present in package.json")
+
+__opts__ = salt.config.minion_config('/etc/salt/minion')
+__utils__ = salt.loader.utils(__opts__)
+__salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
+
+states = __salt__['sys.list_state_modules']()
+state_functions = __salt__['sys.list_state_functions']()
+function_blacklist = ['mod_watch']
+
+any_updates = False
+
+for state in states:
+
+    # Build list of functions for state
+    current_functions = []
+    state_path = os.path.join('snippets', state + '.json')
+    for function in state_functions:
+        if function.startswith('{}.'.format(state)):
+            for blacklist in function_blacklist:
+                # Don't include mod_watch functions as these aren't used in state files
+                if '{}.{}'.format(state, blacklist) not in function:
+                    current_functions.append(function[len('{}.'.format(state)):])
+    snippets = _gen_snippet(state, current_functions)
+
+    if not os.path.exists(state_path):
+        print("Generating basic {}".format(state_path))
+        with open(state_path, 'w') as json_file:
+            json.dump(snippets, json_file, indent='\t')
+    else:
+        data_updated = False
+        with open(state_path, 'r') as json_file:
+            data = json.load(json_file)
+
+        for key in snippets:
+            if key not in data:
+                any_updates = True
+                data_updated = True
+                data[key] = snippets[key]
+                print('Updated {} for {}'.format(key, state))
+        if data_updated:
+            with open(state_path, 'w') as json_file:
+                json.dump(data, json_file, indent='\t')
+
+if not any_updates:
+    print('No changes made to snippet files')
+_add_all_snippets(states)

--- a/generate_snippets.py
+++ b/generate_snippets.py
@@ -6,8 +6,7 @@ the resulting workflow is to run generate_snippets on new salt releases to
 capture any added states or functions. Then hand edit for the defaults which
 make sense.
 '''
-import salt.config
-import salt.loader
+import salt.client
 
 import os
 import json
@@ -61,12 +60,10 @@ def _add_all_snippets(states):
     else:
         print("All states present in package.json")
 
-__opts__ = salt.config.minion_config('/etc/salt/minion')
-__utils__ = salt.loader.utils(__opts__)
-__salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
+local = salt.client.Caller()
 
-states = __salt__['sys.list_state_modules']()
-state_functions = __salt__['sys.list_state_functions']()
+states = local.cmd('sys.list_state_modules')
+state_functions = local.cmd('sys.list_state_functions')
 function_blacklist = ['mod_watch']
 
 any_updates = False

--- a/package.json
+++ b/package.json
@@ -249,6 +249,14 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/certutil.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/chocolatey.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/chronos_job.json"
 			},
 			{
@@ -277,11 +285,19 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/cyg.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/ddns.json"
 			},
 			{
 				"language": "sls",
 				"path": "./snippets/disk.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/dism.json"
 			},
 			{
 				"language": "sls",
@@ -453,6 +469,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/lgpo.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/libcloud_dns.json"
 			},
 			{
@@ -462,6 +482,10 @@
 			{
 				"language": "sls",
 				"path": "./snippets/libcloud_storage.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/license.json"
 			},
 			{
 				"language": "sls",
@@ -525,7 +549,43 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/mssql_database.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mssql_login.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mssql_role.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mssql_user.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/msteams.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mysql_database.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mysql_grants.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mysql_query.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mysql_user.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/network.json"
 			},
 			{
 				"language": "sls",
@@ -534,6 +594,10 @@
 			{
 				"language": "sls",
 				"path": "./snippets/npm.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ntp.json"
 			},
 			{
 				"language": "sls",
@@ -573,6 +637,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/pkg.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/pkgbuild.json"
 			},
 			{
@@ -581,11 +649,19 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/powercfg.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/powerpath.json"
 			},
 			{
 				"language": "sls",
 				"path": "./snippets/process.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/proxy.json"
 			},
 			{
 				"language": "sls",
@@ -598,6 +674,14 @@
 			{
 				"language": "sls",
 				"path": "./snippets/rbenv.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/rdp.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/reg.json"
 			},
 			{
 				"language": "sls",
@@ -626,6 +710,10 @@
 			{
 				"language": "sls",
 				"path": "./snippets/serverdensity_device.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/service.json"
 			},
 			{
 				"language": "sls",
@@ -673,6 +761,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/system.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/telemetry_alert.json"
 			},
 			{
@@ -682,6 +774,10 @@
 			{
 				"language": "sls",
 				"path": "./snippets/timezone.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/tls.json"
 			},
 			{
 				"language": "sls",
@@ -701,6 +797,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/vagrant.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/vault.json"
 			},
 			{
@@ -713,7 +813,39 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/win_dacl.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/win_dns_client.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/win_firewall.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/win_path.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/win_pki.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/win_smtp_server.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/winrepo.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/wua.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/wusa.json"
 			},
 			{
 				"language": "sls",

--- a/package.json
+++ b/package.json
@@ -445,6 +445,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/keystore.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/ldap.json"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "saltstack",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"publisher": "korekontrol",
 	"author": {
 		"name": "Marek Obuchowicz"
@@ -17,7 +17,8 @@
 		"url": "https://github.com/korekontrol/vscode-saltstack/issues"
 	},
 	"categories": [
-		"Languages"
+		"Programming Languages",
+		"Snippets"
 	],
 	"engines": {
 		"vscode": "^1.19.0"
@@ -59,6 +60,12 @@
 				"language": "sls",
 				"scopeName": "text.yaml.jinja",
 				"path": "./syntaxes/sls.json"
+			}
+		],
+		"snippets": [
+			{
+				"language": "sls",
+				"path": "./snippets/test.json"
 			}
 		]
 	}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,487 @@
 		"snippets": [
 			{
 				"language": "sls",
+				"path": "./snippets/alias.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/alternatives.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ansible.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/archive.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/artifactory.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/beacon.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/bigip.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/blockdev.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/buildout.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ceph.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/chronos_job.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/cloud.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/cmd.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/composer.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/cryptdev.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/csf.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/disk.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/elasticsearch.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/elasticsearch_index.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/elasticsearch_index_template.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/environ.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/esxdatacenter.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/etcd.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ethtool.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/event.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/file.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/firewall.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/gem.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/git.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/glassfish.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/gnomedesktop.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/gpg.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/grafana4_dashboard.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/grafana4_datasource.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/grafana4_org.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/grafana4_user.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/grains.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/group.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/highstate_doc.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/host.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/http.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/incron.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/infoblox_a.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/infoblox_cname.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/infoblox_host_record.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/infoblox_range.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ini.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/iptables.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/jboss7.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/jenkins.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/junos.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/keyboard.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ldap.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/libcloud_dns.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/libcloud_loadbalancer.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/libcloud_storage.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/locale.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/logrotate.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/loop.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/lxc.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/marathon_app.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/modjk.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/modjk_worker.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/module.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mount.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/msteams.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/nexus.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/npm.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/openstack_config.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/opsgenie.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pagerduty.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pagerduty_escalation_policy.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pagerduty_schedule.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pagerduty_service.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pagerduty_user.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pip.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pkgbuild.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pkgng.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/powerpath.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/process.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pushover.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/pyenv.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/rbenv.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/rvm.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/salt.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/salt_proxy.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/saltutil.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/schedule.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/serverdensity_device.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/slack.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/smtp.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/solrcloud.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/sqlite3.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ssh_auth.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/ssh_known_hosts.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/stateconf.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/status.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/statuspage.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/supervisord.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/syslog_ng.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/telemetry_alert.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/test.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/timezone.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/tuned.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/uptime.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/user.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/vault.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/vbox_guest.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/virtualenv.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/winrepo.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/xml.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_action.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_host.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_hostgroup.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_mediatype.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_template.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_user.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_usergroup.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_usermacro.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zabbix_valuemap.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/zenoss.json"
 			}
 		]
 	}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,14 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/azurearm_compute.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/azurearm_network.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/beacon.json"
 			},
 			{
@@ -94,6 +102,142 @@
 			{
 				"language": "sls",
 				"path": "./snippets/blockdev.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto3_elasticache.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto3_elasticsearch.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto3_route53.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto3_sns.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_apigateway.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_asg.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_cfn.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_cloudfront.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_cloudtrail.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_cloudwatch_alarm.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_cloudwatch_event.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_cognitoidentity.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_datapipeline.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_dynamodb.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_ec2.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_elasticache.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_elasticsearch_domain.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_elb.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_elbv2.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_iam.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_iam_role.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_iot.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_kinesis.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_kms.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_lambda.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_lc.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_rds.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_route53.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_s3.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_s3_bucket.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_secgroup.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_sns.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_sqs.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/boto_vpc.json"
 			},
 			{
 				"language": "sls",
@@ -121,6 +265,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/cron.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/cryptdev.json"
 			},
 			{
@@ -129,7 +277,31 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/ddns.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/disk.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/docker_container.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/docker_image.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/docker_network.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/docker_volume.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/dvs.json"
 			},
 			{
 				"language": "sls",
@@ -309,6 +481,22 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/moby_container.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/moby_image.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/moby_network.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/moby_volume.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/modjk.json"
 			},
 			{
@@ -318,6 +506,14 @@
 			{
 				"language": "sls",
 				"path": "./snippets/module.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mongodb_database.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/mongodb_user.json"
 			},
 			{
 				"language": "sls",
@@ -365,6 +561,10 @@
 			},
 			{
 				"language": "sls",
+				"path": "./snippets/pbm.json"
+			},
+			{
+				"language": "sls",
 				"path": "./snippets/pip.json"
 			},
 			{
@@ -394,6 +594,10 @@
 			{
 				"language": "sls",
 				"path": "./snippets/rbenv.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/rsync.json"
 			},
 			{
 				"language": "sls",
@@ -474,6 +678,10 @@
 			{
 				"language": "sls",
 				"path": "./snippets/timezone.json"
+			},
+			{
+				"language": "sls",
+				"path": "./snippets/tomcat.json"
 			},
 			{
 				"language": "sls",

--- a/snippets/alias.json
+++ b/snippets/alias.json
@@ -1,0 +1,27 @@
+{
+	"alias state": {
+		"prefix": [
+			"alias."
+		],
+		"body": [
+			"alias.${1|absent,present|}:"
+		],
+		"description": "alias state"
+	},
+	"alias.absent": {
+		"prefix": "alias.absent:",
+		"body": [
+			"alias.absent:",
+			"$0"
+		],
+		"description": "alias.absent:"
+	},
+	"alias.present": {
+		"prefix": "alias.present:",
+		"body": [
+			"alias.present:",
+			"$0"
+		],
+		"description": "alias.present:"
+	}
+}

--- a/snippets/alias.json
+++ b/snippets/alias.json
@@ -1,13 +1,4 @@
 {
-	"alias state": {
-		"prefix": [
-			"alias."
-		],
-		"body": [
-			"alias.${1|absent,present|}:"
-		],
-		"description": "alias state"
-	},
 	"alias.absent": {
 		"prefix": "alias.absent:",
 		"body": [

--- a/snippets/alternatives.json
+++ b/snippets/alternatives.json
@@ -1,13 +1,4 @@
 {
-	"alternatives state": {
-		"prefix": [
-			"alternatives."
-		],
-		"body": [
-			"alternatives.${1|auto,install,remove,set|}:"
-		],
-		"description": "alternatives state"
-	},
 	"alternatives.auto": {
 		"prefix": "alternatives.auto:",
 		"body": [

--- a/snippets/alternatives.json
+++ b/snippets/alternatives.json
@@ -1,0 +1,43 @@
+{
+	"alternatives state": {
+		"prefix": [
+			"alternatives."
+		],
+		"body": [
+			"alternatives.${1|auto,install,remove,set|}:"
+		],
+		"description": "alternatives state"
+	},
+	"alternatives.auto": {
+		"prefix": "alternatives.auto:",
+		"body": [
+			"alternatives.auto:",
+			"$0"
+		],
+		"description": "alternatives.auto:"
+	},
+	"alternatives.install": {
+		"prefix": "alternatives.install:",
+		"body": [
+			"alternatives.install:",
+			"$0"
+		],
+		"description": "alternatives.install:"
+	},
+	"alternatives.remove": {
+		"prefix": "alternatives.remove:",
+		"body": [
+			"alternatives.remove:",
+			"$0"
+		],
+		"description": "alternatives.remove:"
+	},
+	"alternatives.set": {
+		"prefix": "alternatives.set:",
+		"body": [
+			"alternatives.set:",
+			"$0"
+		],
+		"description": "alternatives.set:"
+	}
+}

--- a/snippets/ansible.json
+++ b/snippets/ansible.json
@@ -1,0 +1,27 @@
+{
+	"ansible state": {
+		"prefix": [
+			"ansible."
+		],
+		"body": [
+			"ansible.${1|call,playbooks|}:"
+		],
+		"description": "ansible state"
+	},
+	"ansible.call": {
+		"prefix": "ansible.call:",
+		"body": [
+			"ansible.call:",
+			"$0"
+		],
+		"description": "ansible.call:"
+	},
+	"ansible.playbooks": {
+		"prefix": "ansible.playbooks:",
+		"body": [
+			"ansible.playbooks:",
+			"$0"
+		],
+		"description": "ansible.playbooks:"
+	}
+}

--- a/snippets/ansible.json
+++ b/snippets/ansible.json
@@ -1,13 +1,4 @@
 {
-	"ansible state": {
-		"prefix": [
-			"ansible."
-		],
-		"body": [
-			"ansible.${1|call,playbooks|}:"
-		],
-		"description": "ansible state"
-	},
 	"ansible.call": {
 		"prefix": "ansible.call:",
 		"body": [

--- a/snippets/archive.json
+++ b/snippets/archive.json
@@ -1,0 +1,19 @@
+{
+	"archive state": {
+		"prefix": [
+			"archive."
+		],
+		"body": [
+			"archive.${1|extracted|}:"
+		],
+		"description": "archive state"
+	},
+	"archive.extracted": {
+		"prefix": "archive.extracted:",
+		"body": [
+			"archive.extracted:",
+			"$0"
+		],
+		"description": "archive.extracted:"
+	}
+}

--- a/snippets/archive.json
+++ b/snippets/archive.json
@@ -1,13 +1,4 @@
 {
-	"archive state": {
-		"prefix": [
-			"archive."
-		],
-		"body": [
-			"archive.${1|extracted|}:"
-		],
-		"description": "archive state"
-	},
 	"archive.extracted": {
 		"prefix": "archive.extracted:",
 		"body": [

--- a/snippets/artifactory.json
+++ b/snippets/artifactory.json
@@ -1,0 +1,19 @@
+{
+	"artifactory state": {
+		"prefix": [
+			"artifactory."
+		],
+		"body": [
+			"artifactory.${1|downloaded|}:"
+		],
+		"description": "artifactory state"
+	},
+	"artifactory.downloaded": {
+		"prefix": "artifactory.downloaded:",
+		"body": [
+			"artifactory.downloaded:",
+			"$0"
+		],
+		"description": "artifactory.downloaded:"
+	}
+}

--- a/snippets/artifactory.json
+++ b/snippets/artifactory.json
@@ -1,13 +1,4 @@
 {
-	"artifactory state": {
-		"prefix": [
-			"artifactory."
-		],
-		"body": [
-			"artifactory.${1|downloaded|}:"
-		],
-		"description": "artifactory state"
-	},
 	"artifactory.downloaded": {
 		"prefix": "artifactory.downloaded:",
 		"body": [

--- a/snippets/azurearm_compute.json
+++ b/snippets/azurearm_compute.json
@@ -1,0 +1,18 @@
+{
+	"azurearm_compute.availability_set_absent": {
+		"prefix": "azurearm_compute.availability_set_absent:",
+		"body": [
+			"azurearm_compute.availability_set_absent:",
+			"$0"
+		],
+		"description": "azurearm_compute.availability_set_absent:"
+	},
+	"azurearm_compute.availability_set_present": {
+		"prefix": "azurearm_compute.availability_set_present:",
+		"body": [
+			"azurearm_compute.availability_set_present:",
+			"$0"
+		],
+		"description": "azurearm_compute.availability_set_present:"
+	}
+}

--- a/snippets/azurearm_network.json
+++ b/snippets/azurearm_network.json
@@ -1,0 +1,146 @@
+{
+	"azurearm_network.load_balancer_absent": {
+		"prefix": "azurearm_network.load_balancer_absent:",
+		"body": [
+			"azurearm_network.load_balancer_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.load_balancer_absent:"
+	},
+	"azurearm_network.load_balancer_present": {
+		"prefix": "azurearm_network.load_balancer_present:",
+		"body": [
+			"azurearm_network.load_balancer_present:",
+			"$0"
+		],
+		"description": "azurearm_network.load_balancer_present:"
+	},
+	"azurearm_network.network_interface_absent": {
+		"prefix": "azurearm_network.network_interface_absent:",
+		"body": [
+			"azurearm_network.network_interface_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.network_interface_absent:"
+	},
+	"azurearm_network.network_interface_present": {
+		"prefix": "azurearm_network.network_interface_present:",
+		"body": [
+			"azurearm_network.network_interface_present:",
+			"$0"
+		],
+		"description": "azurearm_network.network_interface_present:"
+	},
+	"azurearm_network.network_security_group_absent": {
+		"prefix": "azurearm_network.network_security_group_absent:",
+		"body": [
+			"azurearm_network.network_security_group_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.network_security_group_absent:"
+	},
+	"azurearm_network.network_security_group_present": {
+		"prefix": "azurearm_network.network_security_group_present:",
+		"body": [
+			"azurearm_network.network_security_group_present:",
+			"$0"
+		],
+		"description": "azurearm_network.network_security_group_present:"
+	},
+	"azurearm_network.public_ip_address_absent": {
+		"prefix": "azurearm_network.public_ip_address_absent:",
+		"body": [
+			"azurearm_network.public_ip_address_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.public_ip_address_absent:"
+	},
+	"azurearm_network.public_ip_address_present": {
+		"prefix": "azurearm_network.public_ip_address_present:",
+		"body": [
+			"azurearm_network.public_ip_address_present:",
+			"$0"
+		],
+		"description": "azurearm_network.public_ip_address_present:"
+	},
+	"azurearm_network.route_absent": {
+		"prefix": "azurearm_network.route_absent:",
+		"body": [
+			"azurearm_network.route_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.route_absent:"
+	},
+	"azurearm_network.route_present": {
+		"prefix": "azurearm_network.route_present:",
+		"body": [
+			"azurearm_network.route_present:",
+			"$0"
+		],
+		"description": "azurearm_network.route_present:"
+	},
+	"azurearm_network.route_table_absent": {
+		"prefix": "azurearm_network.route_table_absent:",
+		"body": [
+			"azurearm_network.route_table_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.route_table_absent:"
+	},
+	"azurearm_network.route_table_present": {
+		"prefix": "azurearm_network.route_table_present:",
+		"body": [
+			"azurearm_network.route_table_present:",
+			"$0"
+		],
+		"description": "azurearm_network.route_table_present:"
+	},
+	"azurearm_network.security_rule_absent": {
+		"prefix": "azurearm_network.security_rule_absent:",
+		"body": [
+			"azurearm_network.security_rule_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.security_rule_absent:"
+	},
+	"azurearm_network.security_rule_present": {
+		"prefix": "azurearm_network.security_rule_present:",
+		"body": [
+			"azurearm_network.security_rule_present:",
+			"$0"
+		],
+		"description": "azurearm_network.security_rule_present:"
+	},
+	"azurearm_network.subnet_absent": {
+		"prefix": "azurearm_network.subnet_absent:",
+		"body": [
+			"azurearm_network.subnet_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.subnet_absent:"
+	},
+	"azurearm_network.subnet_present": {
+		"prefix": "azurearm_network.subnet_present:",
+		"body": [
+			"azurearm_network.subnet_present:",
+			"$0"
+		],
+		"description": "azurearm_network.subnet_present:"
+	},
+	"azurearm_network.virtual_network_absent": {
+		"prefix": "azurearm_network.virtual_network_absent:",
+		"body": [
+			"azurearm_network.virtual_network_absent:",
+			"$0"
+		],
+		"description": "azurearm_network.virtual_network_absent:"
+	},
+	"azurearm_network.virtual_network_present": {
+		"prefix": "azurearm_network.virtual_network_present:",
+		"body": [
+			"azurearm_network.virtual_network_present:",
+			"$0"
+		],
+		"description": "azurearm_network.virtual_network_present:"
+	}
+}

--- a/snippets/beacon.json
+++ b/snippets/beacon.json
@@ -1,0 +1,43 @@
+{
+	"beacon state": {
+		"prefix": [
+			"beacon."
+		],
+		"body": [
+			"beacon.${1|absent,disabled,enabled,present|}:"
+		],
+		"description": "beacon state"
+	},
+	"beacon.absent": {
+		"prefix": "beacon.absent:",
+		"body": [
+			"beacon.absent:",
+			"$0"
+		],
+		"description": "beacon.absent:"
+	},
+	"beacon.disabled": {
+		"prefix": "beacon.disabled:",
+		"body": [
+			"beacon.disabled:",
+			"$0"
+		],
+		"description": "beacon.disabled:"
+	},
+	"beacon.enabled": {
+		"prefix": "beacon.enabled:",
+		"body": [
+			"beacon.enabled:",
+			"$0"
+		],
+		"description": "beacon.enabled:"
+	},
+	"beacon.present": {
+		"prefix": "beacon.present:",
+		"body": [
+			"beacon.present:",
+			"$0"
+		],
+		"description": "beacon.present:"
+	}
+}

--- a/snippets/beacon.json
+++ b/snippets/beacon.json
@@ -1,13 +1,4 @@
 {
-	"beacon state": {
-		"prefix": [
-			"beacon."
-		],
-		"body": [
-			"beacon.${1|absent,disabled,enabled,present|}:"
-		],
-		"description": "beacon state"
-	},
 	"beacon.absent": {
 		"prefix": "beacon.absent:",
 		"body": [

--- a/snippets/bigip.json
+++ b/snippets/bigip.json
@@ -1,0 +1,243 @@
+{
+	"bigip state": {
+		"prefix": [
+			"bigip."
+		],
+		"body": [
+			"bigip.${1|add_pool_member,create_monitor,create_node,create_pool,create_profile,create_virtual,delete_monitor,delete_node,delete_pool,delete_pool_member,delete_profile,delete_virtual,list_monitor,list_node,list_pool,list_profile,list_virtual,manage_monitor,manage_node,manage_pool,manage_pool_members,manage_profile,manage_virtual,modify_monitor,modify_node,modify_pool,modify_pool_member,modify_profile,modify_virtual|}:"
+		],
+		"description": "bigip state"
+	},
+	"bigip.add_pool_member": {
+		"prefix": "bigip.add_pool_member:",
+		"body": [
+			"bigip.add_pool_member:",
+			"$0"
+		],
+		"description": "bigip.add_pool_member:"
+	},
+	"bigip.create_monitor": {
+		"prefix": "bigip.create_monitor:",
+		"body": [
+			"bigip.create_monitor:",
+			"$0"
+		],
+		"description": "bigip.create_monitor:"
+	},
+	"bigip.create_node": {
+		"prefix": "bigip.create_node:",
+		"body": [
+			"bigip.create_node:",
+			"$0"
+		],
+		"description": "bigip.create_node:"
+	},
+	"bigip.create_pool": {
+		"prefix": "bigip.create_pool:",
+		"body": [
+			"bigip.create_pool:",
+			"$0"
+		],
+		"description": "bigip.create_pool:"
+	},
+	"bigip.create_profile": {
+		"prefix": "bigip.create_profile:",
+		"body": [
+			"bigip.create_profile:",
+			"$0"
+		],
+		"description": "bigip.create_profile:"
+	},
+	"bigip.create_virtual": {
+		"prefix": "bigip.create_virtual:",
+		"body": [
+			"bigip.create_virtual:",
+			"$0"
+		],
+		"description": "bigip.create_virtual:"
+	},
+	"bigip.delete_monitor": {
+		"prefix": "bigip.delete_monitor:",
+		"body": [
+			"bigip.delete_monitor:",
+			"$0"
+		],
+		"description": "bigip.delete_monitor:"
+	},
+	"bigip.delete_node": {
+		"prefix": "bigip.delete_node:",
+		"body": [
+			"bigip.delete_node:",
+			"$0"
+		],
+		"description": "bigip.delete_node:"
+	},
+	"bigip.delete_pool": {
+		"prefix": "bigip.delete_pool:",
+		"body": [
+			"bigip.delete_pool:",
+			"$0"
+		],
+		"description": "bigip.delete_pool:"
+	},
+	"bigip.delete_pool_member": {
+		"prefix": "bigip.delete_pool_member:",
+		"body": [
+			"bigip.delete_pool_member:",
+			"$0"
+		],
+		"description": "bigip.delete_pool_member:"
+	},
+	"bigip.delete_profile": {
+		"prefix": "bigip.delete_profile:",
+		"body": [
+			"bigip.delete_profile:",
+			"$0"
+		],
+		"description": "bigip.delete_profile:"
+	},
+	"bigip.delete_virtual": {
+		"prefix": "bigip.delete_virtual:",
+		"body": [
+			"bigip.delete_virtual:",
+			"$0"
+		],
+		"description": "bigip.delete_virtual:"
+	},
+	"bigip.list_monitor": {
+		"prefix": "bigip.list_monitor:",
+		"body": [
+			"bigip.list_monitor:",
+			"$0"
+		],
+		"description": "bigip.list_monitor:"
+	},
+	"bigip.list_node": {
+		"prefix": "bigip.list_node:",
+		"body": [
+			"bigip.list_node:",
+			"$0"
+		],
+		"description": "bigip.list_node:"
+	},
+	"bigip.list_pool": {
+		"prefix": "bigip.list_pool:",
+		"body": [
+			"bigip.list_pool:",
+			"$0"
+		],
+		"description": "bigip.list_pool:"
+	},
+	"bigip.list_profile": {
+		"prefix": "bigip.list_profile:",
+		"body": [
+			"bigip.list_profile:",
+			"$0"
+		],
+		"description": "bigip.list_profile:"
+	},
+	"bigip.list_virtual": {
+		"prefix": "bigip.list_virtual:",
+		"body": [
+			"bigip.list_virtual:",
+			"$0"
+		],
+		"description": "bigip.list_virtual:"
+	},
+	"bigip.manage_monitor": {
+		"prefix": "bigip.manage_monitor:",
+		"body": [
+			"bigip.manage_monitor:",
+			"$0"
+		],
+		"description": "bigip.manage_monitor:"
+	},
+	"bigip.manage_node": {
+		"prefix": "bigip.manage_node:",
+		"body": [
+			"bigip.manage_node:",
+			"$0"
+		],
+		"description": "bigip.manage_node:"
+	},
+	"bigip.manage_pool": {
+		"prefix": "bigip.manage_pool:",
+		"body": [
+			"bigip.manage_pool:",
+			"$0"
+		],
+		"description": "bigip.manage_pool:"
+	},
+	"bigip.manage_pool_members": {
+		"prefix": "bigip.manage_pool_members:",
+		"body": [
+			"bigip.manage_pool_members:",
+			"$0"
+		],
+		"description": "bigip.manage_pool_members:"
+	},
+	"bigip.manage_profile": {
+		"prefix": "bigip.manage_profile:",
+		"body": [
+			"bigip.manage_profile:",
+			"$0"
+		],
+		"description": "bigip.manage_profile:"
+	},
+	"bigip.manage_virtual": {
+		"prefix": "bigip.manage_virtual:",
+		"body": [
+			"bigip.manage_virtual:",
+			"$0"
+		],
+		"description": "bigip.manage_virtual:"
+	},
+	"bigip.modify_monitor": {
+		"prefix": "bigip.modify_monitor:",
+		"body": [
+			"bigip.modify_monitor:",
+			"$0"
+		],
+		"description": "bigip.modify_monitor:"
+	},
+	"bigip.modify_node": {
+		"prefix": "bigip.modify_node:",
+		"body": [
+			"bigip.modify_node:",
+			"$0"
+		],
+		"description": "bigip.modify_node:"
+	},
+	"bigip.modify_pool": {
+		"prefix": "bigip.modify_pool:",
+		"body": [
+			"bigip.modify_pool:",
+			"$0"
+		],
+		"description": "bigip.modify_pool:"
+	},
+	"bigip.modify_pool_member": {
+		"prefix": "bigip.modify_pool_member:",
+		"body": [
+			"bigip.modify_pool_member:",
+			"$0"
+		],
+		"description": "bigip.modify_pool_member:"
+	},
+	"bigip.modify_profile": {
+		"prefix": "bigip.modify_profile:",
+		"body": [
+			"bigip.modify_profile:",
+			"$0"
+		],
+		"description": "bigip.modify_profile:"
+	},
+	"bigip.modify_virtual": {
+		"prefix": "bigip.modify_virtual:",
+		"body": [
+			"bigip.modify_virtual:",
+			"$0"
+		],
+		"description": "bigip.modify_virtual:"
+	}
+}

--- a/snippets/bigip.json
+++ b/snippets/bigip.json
@@ -1,13 +1,4 @@
 {
-	"bigip state": {
-		"prefix": [
-			"bigip."
-		],
-		"body": [
-			"bigip.${1|add_pool_member,create_monitor,create_node,create_pool,create_profile,create_virtual,delete_monitor,delete_node,delete_pool,delete_pool_member,delete_profile,delete_virtual,list_monitor,list_node,list_pool,list_profile,list_virtual,manage_monitor,manage_node,manage_pool,manage_pool_members,manage_profile,manage_virtual,modify_monitor,modify_node,modify_pool,modify_pool_member,modify_profile,modify_virtual|}:"
-		],
-		"description": "bigip state"
-	},
 	"bigip.add_pool_member": {
 		"prefix": "bigip.add_pool_member:",
 		"body": [

--- a/snippets/blockdev.json
+++ b/snippets/blockdev.json
@@ -1,13 +1,4 @@
 {
-	"blockdev state": {
-		"prefix": [
-			"blockdev."
-		],
-		"body": [
-			"blockdev.${1|formatted,tuned|}:"
-		],
-		"description": "blockdev state"
-	},
 	"blockdev.formatted": {
 		"prefix": "blockdev.formatted:",
 		"body": [

--- a/snippets/blockdev.json
+++ b/snippets/blockdev.json
@@ -1,0 +1,27 @@
+{
+	"blockdev state": {
+		"prefix": [
+			"blockdev."
+		],
+		"body": [
+			"blockdev.${1|formatted,tuned|}:"
+		],
+		"description": "blockdev state"
+	},
+	"blockdev.formatted": {
+		"prefix": "blockdev.formatted:",
+		"body": [
+			"blockdev.formatted:",
+			"$0"
+		],
+		"description": "blockdev.formatted:"
+	},
+	"blockdev.tuned": {
+		"prefix": "blockdev.tuned:",
+		"body": [
+			"blockdev.tuned:",
+			"$0"
+		],
+		"description": "blockdev.tuned:"
+	}
+}

--- a/snippets/boto3_elasticache.json
+++ b/snippets/boto3_elasticache.json
@@ -1,0 +1,50 @@
+{
+	"boto3_elasticache.cache_cluster_absent": {
+		"prefix": "boto3_elasticache.cache_cluster_absent:",
+		"body": [
+			"boto3_elasticache.cache_cluster_absent:",
+			"$0"
+		],
+		"description": "boto3_elasticache.cache_cluster_absent:"
+	},
+	"boto3_elasticache.cache_cluster_present": {
+		"prefix": "boto3_elasticache.cache_cluster_present:",
+		"body": [
+			"boto3_elasticache.cache_cluster_present:",
+			"$0"
+		],
+		"description": "boto3_elasticache.cache_cluster_present:"
+	},
+	"boto3_elasticache.cache_subnet_group_absent": {
+		"prefix": "boto3_elasticache.cache_subnet_group_absent:",
+		"body": [
+			"boto3_elasticache.cache_subnet_group_absent:",
+			"$0"
+		],
+		"description": "boto3_elasticache.cache_subnet_group_absent:"
+	},
+	"boto3_elasticache.cache_subnet_group_present": {
+		"prefix": "boto3_elasticache.cache_subnet_group_present:",
+		"body": [
+			"boto3_elasticache.cache_subnet_group_present:",
+			"$0"
+		],
+		"description": "boto3_elasticache.cache_subnet_group_present:"
+	},
+	"boto3_elasticache.replication_group_absent": {
+		"prefix": "boto3_elasticache.replication_group_absent:",
+		"body": [
+			"boto3_elasticache.replication_group_absent:",
+			"$0"
+		],
+		"description": "boto3_elasticache.replication_group_absent:"
+	},
+	"boto3_elasticache.replication_group_present": {
+		"prefix": "boto3_elasticache.replication_group_present:",
+		"body": [
+			"boto3_elasticache.replication_group_present:",
+			"$0"
+		],
+		"description": "boto3_elasticache.replication_group_present:"
+	}
+}

--- a/snippets/boto3_elasticsearch.json
+++ b/snippets/boto3_elasticsearch.json
@@ -1,0 +1,42 @@
+{
+	"boto3_elasticsearch.absent": {
+		"prefix": "boto3_elasticsearch.absent:",
+		"body": [
+			"boto3_elasticsearch.absent:",
+			"$0"
+		],
+		"description": "boto3_elasticsearch.absent:"
+	},
+	"boto3_elasticsearch.latest": {
+		"prefix": "boto3_elasticsearch.latest:",
+		"body": [
+			"boto3_elasticsearch.latest:",
+			"$0"
+		],
+		"description": "boto3_elasticsearch.latest:"
+	},
+	"boto3_elasticsearch.present": {
+		"prefix": "boto3_elasticsearch.present:",
+		"body": [
+			"boto3_elasticsearch.present:",
+			"$0"
+		],
+		"description": "boto3_elasticsearch.present:"
+	},
+	"boto3_elasticsearch.tagged": {
+		"prefix": "boto3_elasticsearch.tagged:",
+		"body": [
+			"boto3_elasticsearch.tagged:",
+			"$0"
+		],
+		"description": "boto3_elasticsearch.tagged:"
+	},
+	"boto3_elasticsearch.upgraded": {
+		"prefix": "boto3_elasticsearch.upgraded:",
+		"body": [
+			"boto3_elasticsearch.upgraded:",
+			"$0"
+		],
+		"description": "boto3_elasticsearch.upgraded:"
+	}
+}

--- a/snippets/boto3_route53.json
+++ b/snippets/boto3_route53.json
@@ -1,0 +1,34 @@
+{
+	"boto3_route53.hosted_zone_absent": {
+		"prefix": "boto3_route53.hosted_zone_absent:",
+		"body": [
+			"boto3_route53.hosted_zone_absent:",
+			"$0"
+		],
+		"description": "boto3_route53.hosted_zone_absent:"
+	},
+	"boto3_route53.hosted_zone_present": {
+		"prefix": "boto3_route53.hosted_zone_present:",
+		"body": [
+			"boto3_route53.hosted_zone_present:",
+			"$0"
+		],
+		"description": "boto3_route53.hosted_zone_present:"
+	},
+	"boto3_route53.rr_absent": {
+		"prefix": "boto3_route53.rr_absent:",
+		"body": [
+			"boto3_route53.rr_absent:",
+			"$0"
+		],
+		"description": "boto3_route53.rr_absent:"
+	},
+	"boto3_route53.rr_present": {
+		"prefix": "boto3_route53.rr_present:",
+		"body": [
+			"boto3_route53.rr_present:",
+			"$0"
+		],
+		"description": "boto3_route53.rr_present:"
+	}
+}

--- a/snippets/boto3_sns.json
+++ b/snippets/boto3_sns.json
@@ -1,0 +1,18 @@
+{
+	"boto3_sns.topic_absent": {
+		"prefix": "boto3_sns.topic_absent:",
+		"body": [
+			"boto3_sns.topic_absent:",
+			"$0"
+		],
+		"description": "boto3_sns.topic_absent:"
+	},
+	"boto3_sns.topic_present": {
+		"prefix": "boto3_sns.topic_present:",
+		"body": [
+			"boto3_sns.topic_present:",
+			"$0"
+		],
+		"description": "boto3_sns.topic_present:"
+	}
+}

--- a/snippets/boto_apigateway.json
+++ b/snippets/boto_apigateway.json
@@ -1,0 +1,50 @@
+{
+	"boto_apigateway.absent": {
+		"prefix": "boto_apigateway.absent:",
+		"body": [
+			"boto_apigateway.absent:",
+			"$0"
+		],
+		"description": "boto_apigateway.absent:"
+	},
+	"boto_apigateway.present": {
+		"prefix": "boto_apigateway.present:",
+		"body": [
+			"boto_apigateway.present:",
+			"$0"
+		],
+		"description": "boto_apigateway.present:"
+	},
+	"boto_apigateway.usage_plan_absent": {
+		"prefix": "boto_apigateway.usage_plan_absent:",
+		"body": [
+			"boto_apigateway.usage_plan_absent:",
+			"$0"
+		],
+		"description": "boto_apigateway.usage_plan_absent:"
+	},
+	"boto_apigateway.usage_plan_association_absent": {
+		"prefix": "boto_apigateway.usage_plan_association_absent:",
+		"body": [
+			"boto_apigateway.usage_plan_association_absent:",
+			"$0"
+		],
+		"description": "boto_apigateway.usage_plan_association_absent:"
+	},
+	"boto_apigateway.usage_plan_association_present": {
+		"prefix": "boto_apigateway.usage_plan_association_present:",
+		"body": [
+			"boto_apigateway.usage_plan_association_present:",
+			"$0"
+		],
+		"description": "boto_apigateway.usage_plan_association_present:"
+	},
+	"boto_apigateway.usage_plan_present": {
+		"prefix": "boto_apigateway.usage_plan_present:",
+		"body": [
+			"boto_apigateway.usage_plan_present:",
+			"$0"
+		],
+		"description": "boto_apigateway.usage_plan_present:"
+	}
+}

--- a/snippets/boto_asg.json
+++ b/snippets/boto_asg.json
@@ -1,0 +1,18 @@
+{
+	"boto_asg.absent": {
+		"prefix": "boto_asg.absent:",
+		"body": [
+			"boto_asg.absent:",
+			"$0"
+		],
+		"description": "boto_asg.absent:"
+	},
+	"boto_asg.present": {
+		"prefix": "boto_asg.present:",
+		"body": [
+			"boto_asg.present:",
+			"$0"
+		],
+		"description": "boto_asg.present:"
+	}
+}

--- a/snippets/boto_cfn.json
+++ b/snippets/boto_cfn.json
@@ -1,0 +1,18 @@
+{
+	"boto_cfn.absent": {
+		"prefix": "boto_cfn.absent:",
+		"body": [
+			"boto_cfn.absent:",
+			"$0"
+		],
+		"description": "boto_cfn.absent:"
+	},
+	"boto_cfn.present": {
+		"prefix": "boto_cfn.present:",
+		"body": [
+			"boto_cfn.present:",
+			"$0"
+		],
+		"description": "boto_cfn.present:"
+	}
+}

--- a/snippets/boto_cloudfront.json
+++ b/snippets/boto_cloudfront.json
@@ -1,0 +1,10 @@
+{
+	"boto_cloudfront.present": {
+		"prefix": "boto_cloudfront.present:",
+		"body": [
+			"boto_cloudfront.present:",
+			"$0"
+		],
+		"description": "boto_cloudfront.present:"
+	}
+}

--- a/snippets/boto_cloudtrail.json
+++ b/snippets/boto_cloudtrail.json
@@ -1,0 +1,18 @@
+{
+	"boto_cloudtrail.absent": {
+		"prefix": "boto_cloudtrail.absent:",
+		"body": [
+			"boto_cloudtrail.absent:",
+			"$0"
+		],
+		"description": "boto_cloudtrail.absent:"
+	},
+	"boto_cloudtrail.present": {
+		"prefix": "boto_cloudtrail.present:",
+		"body": [
+			"boto_cloudtrail.present:",
+			"$0"
+		],
+		"description": "boto_cloudtrail.present:"
+	}
+}

--- a/snippets/boto_cloudwatch_alarm.json
+++ b/snippets/boto_cloudwatch_alarm.json
@@ -1,0 +1,18 @@
+{
+	"boto_cloudwatch_alarm.absent": {
+		"prefix": "boto_cloudwatch_alarm.absent:",
+		"body": [
+			"boto_cloudwatch_alarm.absent:",
+			"$0"
+		],
+		"description": "boto_cloudwatch_alarm.absent:"
+	},
+	"boto_cloudwatch_alarm.present": {
+		"prefix": "boto_cloudwatch_alarm.present:",
+		"body": [
+			"boto_cloudwatch_alarm.present:",
+			"$0"
+		],
+		"description": "boto_cloudwatch_alarm.present:"
+	}
+}

--- a/snippets/boto_cloudwatch_event.json
+++ b/snippets/boto_cloudwatch_event.json
@@ -1,0 +1,18 @@
+{
+	"boto_cloudwatch_event.absent": {
+		"prefix": "boto_cloudwatch_event.absent:",
+		"body": [
+			"boto_cloudwatch_event.absent:",
+			"$0"
+		],
+		"description": "boto_cloudwatch_event.absent:"
+	},
+	"boto_cloudwatch_event.present": {
+		"prefix": "boto_cloudwatch_event.present:",
+		"body": [
+			"boto_cloudwatch_event.present:",
+			"$0"
+		],
+		"description": "boto_cloudwatch_event.present:"
+	}
+}

--- a/snippets/boto_cognitoidentity.json
+++ b/snippets/boto_cognitoidentity.json
@@ -1,0 +1,18 @@
+{
+	"boto_cognitoidentity.pool_absent": {
+		"prefix": "boto_cognitoidentity.pool_absent:",
+		"body": [
+			"boto_cognitoidentity.pool_absent:",
+			"$0"
+		],
+		"description": "boto_cognitoidentity.pool_absent:"
+	},
+	"boto_cognitoidentity.pool_present": {
+		"prefix": "boto_cognitoidentity.pool_present:",
+		"body": [
+			"boto_cognitoidentity.pool_present:",
+			"$0"
+		],
+		"description": "boto_cognitoidentity.pool_present:"
+	}
+}

--- a/snippets/boto_datapipeline.json
+++ b/snippets/boto_datapipeline.json
@@ -1,0 +1,18 @@
+{
+	"boto_datapipeline.absent": {
+		"prefix": "boto_datapipeline.absent:",
+		"body": [
+			"boto_datapipeline.absent:",
+			"$0"
+		],
+		"description": "boto_datapipeline.absent:"
+	},
+	"boto_datapipeline.present": {
+		"prefix": "boto_datapipeline.present:",
+		"body": [
+			"boto_datapipeline.present:",
+			"$0"
+		],
+		"description": "boto_datapipeline.present:"
+	}
+}

--- a/snippets/boto_dynamodb.json
+++ b/snippets/boto_dynamodb.json
@@ -1,0 +1,18 @@
+{
+	"boto_dynamodb.absent": {
+		"prefix": "boto_dynamodb.absent:",
+		"body": [
+			"boto_dynamodb.absent:",
+			"$0"
+		],
+		"description": "boto_dynamodb.absent:"
+	},
+	"boto_dynamodb.present": {
+		"prefix": "boto_dynamodb.present:",
+		"body": [
+			"boto_dynamodb.present:",
+			"$0"
+		],
+		"description": "boto_dynamodb.present:"
+	}
+}

--- a/snippets/boto_ec2.json
+++ b/snippets/boto_ec2.json
@@ -1,0 +1,98 @@
+{
+	"boto_ec2.eni_absent": {
+		"prefix": "boto_ec2.eni_absent:",
+		"body": [
+			"boto_ec2.eni_absent:",
+			"$0"
+		],
+		"description": "boto_ec2.eni_absent:"
+	},
+	"boto_ec2.eni_present": {
+		"prefix": "boto_ec2.eni_present:",
+		"body": [
+			"boto_ec2.eni_present:",
+			"$0"
+		],
+		"description": "boto_ec2.eni_present:"
+	},
+	"boto_ec2.instance_absent": {
+		"prefix": "boto_ec2.instance_absent:",
+		"body": [
+			"boto_ec2.instance_absent:",
+			"$0"
+		],
+		"description": "boto_ec2.instance_absent:"
+	},
+	"boto_ec2.instance_present": {
+		"prefix": "boto_ec2.instance_present:",
+		"body": [
+			"boto_ec2.instance_present:",
+			"$0"
+		],
+		"description": "boto_ec2.instance_present:"
+	},
+	"boto_ec2.key_absent": {
+		"prefix": "boto_ec2.key_absent:",
+		"body": [
+			"boto_ec2.key_absent:",
+			"$0"
+		],
+		"description": "boto_ec2.key_absent:"
+	},
+	"boto_ec2.key_present": {
+		"prefix": "boto_ec2.key_present:",
+		"body": [
+			"boto_ec2.key_present:",
+			"$0"
+		],
+		"description": "boto_ec2.key_present:"
+	},
+	"boto_ec2.private_ips_absent": {
+		"prefix": "boto_ec2.private_ips_absent:",
+		"body": [
+			"boto_ec2.private_ips_absent:",
+			"$0"
+		],
+		"description": "boto_ec2.private_ips_absent:"
+	},
+	"boto_ec2.private_ips_present": {
+		"prefix": "boto_ec2.private_ips_present:",
+		"body": [
+			"boto_ec2.private_ips_present:",
+			"$0"
+		],
+		"description": "boto_ec2.private_ips_present:"
+	},
+	"boto_ec2.snapshot_created": {
+		"prefix": "boto_ec2.snapshot_created:",
+		"body": [
+			"boto_ec2.snapshot_created:",
+			"$0"
+		],
+		"description": "boto_ec2.snapshot_created:"
+	},
+	"boto_ec2.volume_absent": {
+		"prefix": "boto_ec2.volume_absent:",
+		"body": [
+			"boto_ec2.volume_absent:",
+			"$0"
+		],
+		"description": "boto_ec2.volume_absent:"
+	},
+	"boto_ec2.volume_present": {
+		"prefix": "boto_ec2.volume_present:",
+		"body": [
+			"boto_ec2.volume_present:",
+			"$0"
+		],
+		"description": "boto_ec2.volume_present:"
+	},
+	"boto_ec2.volumes_tagged": {
+		"prefix": "boto_ec2.volumes_tagged:",
+		"body": [
+			"boto_ec2.volumes_tagged:",
+			"$0"
+		],
+		"description": "boto_ec2.volumes_tagged:"
+	}
+}

--- a/snippets/boto_elasticache.json
+++ b/snippets/boto_elasticache.json
@@ -1,0 +1,74 @@
+{
+	"boto_elasticache.absent": {
+		"prefix": "boto_elasticache.absent:",
+		"body": [
+			"boto_elasticache.absent:",
+			"$0"
+		],
+		"description": "boto_elasticache.absent:"
+	},
+	"boto_elasticache.cache_cluster_absent": {
+		"prefix": "boto_elasticache.cache_cluster_absent:",
+		"body": [
+			"boto_elasticache.cache_cluster_absent:",
+			"$0"
+		],
+		"description": "boto_elasticache.cache_cluster_absent:"
+	},
+	"boto_elasticache.cache_cluster_present": {
+		"prefix": "boto_elasticache.cache_cluster_present:",
+		"body": [
+			"boto_elasticache.cache_cluster_present:",
+			"$0"
+		],
+		"description": "boto_elasticache.cache_cluster_present:"
+	},
+	"boto_elasticache.creategroup": {
+		"prefix": "boto_elasticache.creategroup:",
+		"body": [
+			"boto_elasticache.creategroup:",
+			"$0"
+		],
+		"description": "boto_elasticache.creategroup:"
+	},
+	"boto_elasticache.present": {
+		"prefix": "boto_elasticache.present:",
+		"body": [
+			"boto_elasticache.present:",
+			"$0"
+		],
+		"description": "boto_elasticache.present:"
+	},
+	"boto_elasticache.replication_group_absent": {
+		"prefix": "boto_elasticache.replication_group_absent:",
+		"body": [
+			"boto_elasticache.replication_group_absent:",
+			"$0"
+		],
+		"description": "boto_elasticache.replication_group_absent:"
+	},
+	"boto_elasticache.replication_group_present": {
+		"prefix": "boto_elasticache.replication_group_present:",
+		"body": [
+			"boto_elasticache.replication_group_present:",
+			"$0"
+		],
+		"description": "boto_elasticache.replication_group_present:"
+	},
+	"boto_elasticache.subnet_group_absent": {
+		"prefix": "boto_elasticache.subnet_group_absent:",
+		"body": [
+			"boto_elasticache.subnet_group_absent:",
+			"$0"
+		],
+		"description": "boto_elasticache.subnet_group_absent:"
+	},
+	"boto_elasticache.subnet_group_present": {
+		"prefix": "boto_elasticache.subnet_group_present:",
+		"body": [
+			"boto_elasticache.subnet_group_present:",
+			"$0"
+		],
+		"description": "boto_elasticache.subnet_group_present:"
+	}
+}

--- a/snippets/boto_elasticsearch_domain.json
+++ b/snippets/boto_elasticsearch_domain.json
@@ -1,0 +1,18 @@
+{
+	"boto_elasticsearch_domain.absent": {
+		"prefix": "boto_elasticsearch_domain.absent:",
+		"body": [
+			"boto_elasticsearch_domain.absent:",
+			"$0"
+		],
+		"description": "boto_elasticsearch_domain.absent:"
+	},
+	"boto_elasticsearch_domain.present": {
+		"prefix": "boto_elasticsearch_domain.present:",
+		"body": [
+			"boto_elasticsearch_domain.present:",
+			"$0"
+		],
+		"description": "boto_elasticsearch_domain.present:"
+	}
+}

--- a/snippets/boto_elb.json
+++ b/snippets/boto_elb.json
@@ -1,0 +1,26 @@
+{
+	"boto_elb.absent": {
+		"prefix": "boto_elb.absent:",
+		"body": [
+			"boto_elb.absent:",
+			"$0"
+		],
+		"description": "boto_elb.absent:"
+	},
+	"boto_elb.present": {
+		"prefix": "boto_elb.present:",
+		"body": [
+			"boto_elb.present:",
+			"$0"
+		],
+		"description": "boto_elb.present:"
+	},
+	"boto_elb.register_instances": {
+		"prefix": "boto_elb.register_instances:",
+		"body": [
+			"boto_elb.register_instances:",
+			"$0"
+		],
+		"description": "boto_elb.register_instances:"
+	}
+}

--- a/snippets/boto_elbv2.json
+++ b/snippets/boto_elbv2.json
@@ -1,0 +1,34 @@
+{
+	"boto_elbv2.create_target_group": {
+		"prefix": "boto_elbv2.create_target_group:",
+		"body": [
+			"boto_elbv2.create_target_group:",
+			"$0"
+		],
+		"description": "boto_elbv2.create_target_group:"
+	},
+	"boto_elbv2.delete_target_group": {
+		"prefix": "boto_elbv2.delete_target_group:",
+		"body": [
+			"boto_elbv2.delete_target_group:",
+			"$0"
+		],
+		"description": "boto_elbv2.delete_target_group:"
+	},
+	"boto_elbv2.targets_deregistered": {
+		"prefix": "boto_elbv2.targets_deregistered:",
+		"body": [
+			"boto_elbv2.targets_deregistered:",
+			"$0"
+		],
+		"description": "boto_elbv2.targets_deregistered:"
+	},
+	"boto_elbv2.targets_registered": {
+		"prefix": "boto_elbv2.targets_registered:",
+		"body": [
+			"boto_elbv2.targets_registered:",
+			"$0"
+		],
+		"description": "boto_elbv2.targets_registered:"
+	}
+}

--- a/snippets/boto_iam.json
+++ b/snippets/boto_iam.json
@@ -1,0 +1,106 @@
+{
+	"boto_iam.account_policy": {
+		"prefix": "boto_iam.account_policy:",
+		"body": [
+			"boto_iam.account_policy:",
+			"$0"
+		],
+		"description": "boto_iam.account_policy:"
+	},
+	"boto_iam.group_absent": {
+		"prefix": "boto_iam.group_absent:",
+		"body": [
+			"boto_iam.group_absent:",
+			"$0"
+		],
+		"description": "boto_iam.group_absent:"
+	},
+	"boto_iam.group_present": {
+		"prefix": "boto_iam.group_present:",
+		"body": [
+			"boto_iam.group_present:",
+			"$0"
+		],
+		"description": "boto_iam.group_present:"
+	},
+	"boto_iam.keys_absent": {
+		"prefix": "boto_iam.keys_absent:",
+		"body": [
+			"boto_iam.keys_absent:",
+			"$0"
+		],
+		"description": "boto_iam.keys_absent:"
+	},
+	"boto_iam.keys_present": {
+		"prefix": "boto_iam.keys_present:",
+		"body": [
+			"boto_iam.keys_present:",
+			"$0"
+		],
+		"description": "boto_iam.keys_present:"
+	},
+	"boto_iam.policy_absent": {
+		"prefix": "boto_iam.policy_absent:",
+		"body": [
+			"boto_iam.policy_absent:",
+			"$0"
+		],
+		"description": "boto_iam.policy_absent:"
+	},
+	"boto_iam.policy_present": {
+		"prefix": "boto_iam.policy_present:",
+		"body": [
+			"boto_iam.policy_present:",
+			"$0"
+		],
+		"description": "boto_iam.policy_present:"
+	},
+	"boto_iam.saml_provider_absent": {
+		"prefix": "boto_iam.saml_provider_absent:",
+		"body": [
+			"boto_iam.saml_provider_absent:",
+			"$0"
+		],
+		"description": "boto_iam.saml_provider_absent:"
+	},
+	"boto_iam.saml_provider_present": {
+		"prefix": "boto_iam.saml_provider_present:",
+		"body": [
+			"boto_iam.saml_provider_present:",
+			"$0"
+		],
+		"description": "boto_iam.saml_provider_present:"
+	},
+	"boto_iam.server_cert_absent": {
+		"prefix": "boto_iam.server_cert_absent:",
+		"body": [
+			"boto_iam.server_cert_absent:",
+			"$0"
+		],
+		"description": "boto_iam.server_cert_absent:"
+	},
+	"boto_iam.server_cert_present": {
+		"prefix": "boto_iam.server_cert_present:",
+		"body": [
+			"boto_iam.server_cert_present:",
+			"$0"
+		],
+		"description": "boto_iam.server_cert_present:"
+	},
+	"boto_iam.user_absent": {
+		"prefix": "boto_iam.user_absent:",
+		"body": [
+			"boto_iam.user_absent:",
+			"$0"
+		],
+		"description": "boto_iam.user_absent:"
+	},
+	"boto_iam.user_present": {
+		"prefix": "boto_iam.user_present:",
+		"body": [
+			"boto_iam.user_present:",
+			"$0"
+		],
+		"description": "boto_iam.user_present:"
+	}
+}

--- a/snippets/boto_iam_role.json
+++ b/snippets/boto_iam_role.json
@@ -1,0 +1,18 @@
+{
+	"boto_iam_role.absent": {
+		"prefix": "boto_iam_role.absent:",
+		"body": [
+			"boto_iam_role.absent:",
+			"$0"
+		],
+		"description": "boto_iam_role.absent:"
+	},
+	"boto_iam_role.present": {
+		"prefix": "boto_iam_role.present:",
+		"body": [
+			"boto_iam_role.present:",
+			"$0"
+		],
+		"description": "boto_iam_role.present:"
+	}
+}

--- a/snippets/boto_iot.json
+++ b/snippets/boto_iot.json
@@ -1,0 +1,66 @@
+{
+	"boto_iot.policy_absent": {
+		"prefix": "boto_iot.policy_absent:",
+		"body": [
+			"boto_iot.policy_absent:",
+			"$0"
+		],
+		"description": "boto_iot.policy_absent:"
+	},
+	"boto_iot.policy_attached": {
+		"prefix": "boto_iot.policy_attached:",
+		"body": [
+			"boto_iot.policy_attached:",
+			"$0"
+		],
+		"description": "boto_iot.policy_attached:"
+	},
+	"boto_iot.policy_detached": {
+		"prefix": "boto_iot.policy_detached:",
+		"body": [
+			"boto_iot.policy_detached:",
+			"$0"
+		],
+		"description": "boto_iot.policy_detached:"
+	},
+	"boto_iot.policy_present": {
+		"prefix": "boto_iot.policy_present:",
+		"body": [
+			"boto_iot.policy_present:",
+			"$0"
+		],
+		"description": "boto_iot.policy_present:"
+	},
+	"boto_iot.thing_type_absent": {
+		"prefix": "boto_iot.thing_type_absent:",
+		"body": [
+			"boto_iot.thing_type_absent:",
+			"$0"
+		],
+		"description": "boto_iot.thing_type_absent:"
+	},
+	"boto_iot.thing_type_present": {
+		"prefix": "boto_iot.thing_type_present:",
+		"body": [
+			"boto_iot.thing_type_present:",
+			"$0"
+		],
+		"description": "boto_iot.thing_type_present:"
+	},
+	"boto_iot.topic_rule_absent": {
+		"prefix": "boto_iot.topic_rule_absent:",
+		"body": [
+			"boto_iot.topic_rule_absent:",
+			"$0"
+		],
+		"description": "boto_iot.topic_rule_absent:"
+	},
+	"boto_iot.topic_rule_present": {
+		"prefix": "boto_iot.topic_rule_present:",
+		"body": [
+			"boto_iot.topic_rule_present:",
+			"$0"
+		],
+		"description": "boto_iot.topic_rule_present:"
+	}
+}

--- a/snippets/boto_kinesis.json
+++ b/snippets/boto_kinesis.json
@@ -1,0 +1,18 @@
+{
+	"boto_kinesis.absent": {
+		"prefix": "boto_kinesis.absent:",
+		"body": [
+			"boto_kinesis.absent:",
+			"$0"
+		],
+		"description": "boto_kinesis.absent:"
+	},
+	"boto_kinesis.present": {
+		"prefix": "boto_kinesis.present:",
+		"body": [
+			"boto_kinesis.present:",
+			"$0"
+		],
+		"description": "boto_kinesis.present:"
+	}
+}

--- a/snippets/boto_kms.json
+++ b/snippets/boto_kms.json
@@ -1,0 +1,10 @@
+{
+	"boto_kms.key_present": {
+		"prefix": "boto_kms.key_present:",
+		"body": [
+			"boto_kms.key_present:",
+			"$0"
+		],
+		"description": "boto_kms.key_present:"
+	}
+}

--- a/snippets/boto_lambda.json
+++ b/snippets/boto_lambda.json
@@ -1,0 +1,50 @@
+{
+	"boto_lambda.alias_absent": {
+		"prefix": "boto_lambda.alias_absent:",
+		"body": [
+			"boto_lambda.alias_absent:",
+			"$0"
+		],
+		"description": "boto_lambda.alias_absent:"
+	},
+	"boto_lambda.alias_present": {
+		"prefix": "boto_lambda.alias_present:",
+		"body": [
+			"boto_lambda.alias_present:",
+			"$0"
+		],
+		"description": "boto_lambda.alias_present:"
+	},
+	"boto_lambda.event_source_mapping_absent": {
+		"prefix": "boto_lambda.event_source_mapping_absent:",
+		"body": [
+			"boto_lambda.event_source_mapping_absent:",
+			"$0"
+		],
+		"description": "boto_lambda.event_source_mapping_absent:"
+	},
+	"boto_lambda.event_source_mapping_present": {
+		"prefix": "boto_lambda.event_source_mapping_present:",
+		"body": [
+			"boto_lambda.event_source_mapping_present:",
+			"$0"
+		],
+		"description": "boto_lambda.event_source_mapping_present:"
+	},
+	"boto_lambda.function_absent": {
+		"prefix": "boto_lambda.function_absent:",
+		"body": [
+			"boto_lambda.function_absent:",
+			"$0"
+		],
+		"description": "boto_lambda.function_absent:"
+	},
+	"boto_lambda.function_present": {
+		"prefix": "boto_lambda.function_present:",
+		"body": [
+			"boto_lambda.function_present:",
+			"$0"
+		],
+		"description": "boto_lambda.function_present:"
+	}
+}

--- a/snippets/boto_lc.json
+++ b/snippets/boto_lc.json
@@ -1,0 +1,18 @@
+{
+	"boto_lc.absent": {
+		"prefix": "boto_lc.absent:",
+		"body": [
+			"boto_lc.absent:",
+			"$0"
+		],
+		"description": "boto_lc.absent:"
+	},
+	"boto_lc.present": {
+		"prefix": "boto_lc.present:",
+		"body": [
+			"boto_lc.present:",
+			"$0"
+		],
+		"description": "boto_lc.present:"
+	}
+}

--- a/snippets/boto_rds.json
+++ b/snippets/boto_rds.json
@@ -1,0 +1,50 @@
+{
+	"boto_rds.absent": {
+		"prefix": "boto_rds.absent:",
+		"body": [
+			"boto_rds.absent:",
+			"$0"
+		],
+		"description": "boto_rds.absent:"
+	},
+	"boto_rds.parameter_present": {
+		"prefix": "boto_rds.parameter_present:",
+		"body": [
+			"boto_rds.parameter_present:",
+			"$0"
+		],
+		"description": "boto_rds.parameter_present:"
+	},
+	"boto_rds.present": {
+		"prefix": "boto_rds.present:",
+		"body": [
+			"boto_rds.present:",
+			"$0"
+		],
+		"description": "boto_rds.present:"
+	},
+	"boto_rds.replica_present": {
+		"prefix": "boto_rds.replica_present:",
+		"body": [
+			"boto_rds.replica_present:",
+			"$0"
+		],
+		"description": "boto_rds.replica_present:"
+	},
+	"boto_rds.subnet_group_absent": {
+		"prefix": "boto_rds.subnet_group_absent:",
+		"body": [
+			"boto_rds.subnet_group_absent:",
+			"$0"
+		],
+		"description": "boto_rds.subnet_group_absent:"
+	},
+	"boto_rds.subnet_group_present": {
+		"prefix": "boto_rds.subnet_group_present:",
+		"body": [
+			"boto_rds.subnet_group_present:",
+			"$0"
+		],
+		"description": "boto_rds.subnet_group_present:"
+	}
+}

--- a/snippets/boto_route53.json
+++ b/snippets/boto_route53.json
@@ -1,0 +1,50 @@
+{
+	"boto_route53.absent": {
+		"prefix": "boto_route53.absent:",
+		"body": [
+			"boto_route53.absent:",
+			"$0"
+		],
+		"description": "boto_route53.absent:"
+	},
+	"boto_route53.hosted_zone_absent": {
+		"prefix": "boto_route53.hosted_zone_absent:",
+		"body": [
+			"boto_route53.hosted_zone_absent:",
+			"$0"
+		],
+		"description": "boto_route53.hosted_zone_absent:"
+	},
+	"boto_route53.hosted_zone_present": {
+		"prefix": "boto_route53.hosted_zone_present:",
+		"body": [
+			"boto_route53.hosted_zone_present:",
+			"$0"
+		],
+		"description": "boto_route53.hosted_zone_present:"
+	},
+	"boto_route53.present": {
+		"prefix": "boto_route53.present:",
+		"body": [
+			"boto_route53.present:",
+			"$0"
+		],
+		"description": "boto_route53.present:"
+	},
+	"boto_route53.rr_absent": {
+		"prefix": "boto_route53.rr_absent:",
+		"body": [
+			"boto_route53.rr_absent:",
+			"$0"
+		],
+		"description": "boto_route53.rr_absent:"
+	},
+	"boto_route53.rr_present": {
+		"prefix": "boto_route53.rr_present:",
+		"body": [
+			"boto_route53.rr_present:",
+			"$0"
+		],
+		"description": "boto_route53.rr_present:"
+	}
+}

--- a/snippets/boto_s3.json
+++ b/snippets/boto_s3.json
@@ -1,0 +1,10 @@
+{
+	"boto_s3.object_present": {
+		"prefix": "boto_s3.object_present:",
+		"body": [
+			"boto_s3.object_present:",
+			"$0"
+		],
+		"description": "boto_s3.object_present:"
+	}
+}

--- a/snippets/boto_s3_bucket.json
+++ b/snippets/boto_s3_bucket.json
@@ -1,0 +1,18 @@
+{
+	"boto_s3_bucket.absent": {
+		"prefix": "boto_s3_bucket.absent:",
+		"body": [
+			"boto_s3_bucket.absent:",
+			"$0"
+		],
+		"description": "boto_s3_bucket.absent:"
+	},
+	"boto_s3_bucket.present": {
+		"prefix": "boto_s3_bucket.present:",
+		"body": [
+			"boto_s3_bucket.present:",
+			"$0"
+		],
+		"description": "boto_s3_bucket.present:"
+	}
+}

--- a/snippets/boto_secgroup.json
+++ b/snippets/boto_secgroup.json
@@ -1,0 +1,18 @@
+{
+	"boto_secgroup.absent": {
+		"prefix": "boto_secgroup.absent:",
+		"body": [
+			"boto_secgroup.absent:",
+			"$0"
+		],
+		"description": "boto_secgroup.absent:"
+	},
+	"boto_secgroup.present": {
+		"prefix": "boto_secgroup.present:",
+		"body": [
+			"boto_secgroup.present:",
+			"$0"
+		],
+		"description": "boto_secgroup.present:"
+	}
+}

--- a/snippets/boto_sns.json
+++ b/snippets/boto_sns.json
@@ -1,0 +1,18 @@
+{
+	"boto_sns.absent": {
+		"prefix": "boto_sns.absent:",
+		"body": [
+			"boto_sns.absent:",
+			"$0"
+		],
+		"description": "boto_sns.absent:"
+	},
+	"boto_sns.present": {
+		"prefix": "boto_sns.present:",
+		"body": [
+			"boto_sns.present:",
+			"$0"
+		],
+		"description": "boto_sns.present:"
+	}
+}

--- a/snippets/boto_sqs.json
+++ b/snippets/boto_sqs.json
@@ -1,0 +1,18 @@
+{
+	"boto_sqs.absent": {
+		"prefix": "boto_sqs.absent:",
+		"body": [
+			"boto_sqs.absent:",
+			"$0"
+		],
+		"description": "boto_sqs.absent:"
+	},
+	"boto_sqs.present": {
+		"prefix": "boto_sqs.present:",
+		"body": [
+			"boto_sqs.present:",
+			"$0"
+		],
+		"description": "boto_sqs.present:"
+	}
+}

--- a/snippets/boto_vpc.json
+++ b/snippets/boto_vpc.json
@@ -1,0 +1,138 @@
+{
+	"boto_vpc.absent": {
+		"prefix": "boto_vpc.absent:",
+		"body": [
+			"boto_vpc.absent:",
+			"$0"
+		],
+		"description": "boto_vpc.absent:"
+	},
+	"boto_vpc.accept_vpc_peering_connection": {
+		"prefix": "boto_vpc.accept_vpc_peering_connection:",
+		"body": [
+			"boto_vpc.accept_vpc_peering_connection:",
+			"$0"
+		],
+		"description": "boto_vpc.accept_vpc_peering_connection:"
+	},
+	"boto_vpc.delete_vpc_peering_connection": {
+		"prefix": "boto_vpc.delete_vpc_peering_connection:",
+		"body": [
+			"boto_vpc.delete_vpc_peering_connection:",
+			"$0"
+		],
+		"description": "boto_vpc.delete_vpc_peering_connection:"
+	},
+	"boto_vpc.dhcp_options_absent": {
+		"prefix": "boto_vpc.dhcp_options_absent:",
+		"body": [
+			"boto_vpc.dhcp_options_absent:",
+			"$0"
+		],
+		"description": "boto_vpc.dhcp_options_absent:"
+	},
+	"boto_vpc.dhcp_options_present": {
+		"prefix": "boto_vpc.dhcp_options_present:",
+		"body": [
+			"boto_vpc.dhcp_options_present:",
+			"$0"
+		],
+		"description": "boto_vpc.dhcp_options_present:"
+	},
+	"boto_vpc.internet_gateway_absent": {
+		"prefix": "boto_vpc.internet_gateway_absent:",
+		"body": [
+			"boto_vpc.internet_gateway_absent:",
+			"$0"
+		],
+		"description": "boto_vpc.internet_gateway_absent:"
+	},
+	"boto_vpc.internet_gateway_present": {
+		"prefix": "boto_vpc.internet_gateway_present:",
+		"body": [
+			"boto_vpc.internet_gateway_present:",
+			"$0"
+		],
+		"description": "boto_vpc.internet_gateway_present:"
+	},
+	"boto_vpc.nat_gateway_absent": {
+		"prefix": "boto_vpc.nat_gateway_absent:",
+		"body": [
+			"boto_vpc.nat_gateway_absent:",
+			"$0"
+		],
+		"description": "boto_vpc.nat_gateway_absent:"
+	},
+	"boto_vpc.nat_gateway_present": {
+		"prefix": "boto_vpc.nat_gateway_present:",
+		"body": [
+			"boto_vpc.nat_gateway_present:",
+			"$0"
+		],
+		"description": "boto_vpc.nat_gateway_present:"
+	},
+	"boto_vpc.present": {
+		"prefix": "boto_vpc.present:",
+		"body": [
+			"boto_vpc.present:",
+			"$0"
+		],
+		"description": "boto_vpc.present:"
+	},
+	"boto_vpc.request_vpc_peering_connection": {
+		"prefix": "boto_vpc.request_vpc_peering_connection:",
+		"body": [
+			"boto_vpc.request_vpc_peering_connection:",
+			"$0"
+		],
+		"description": "boto_vpc.request_vpc_peering_connection:"
+	},
+	"boto_vpc.route_table_absent": {
+		"prefix": "boto_vpc.route_table_absent:",
+		"body": [
+			"boto_vpc.route_table_absent:",
+			"$0"
+		],
+		"description": "boto_vpc.route_table_absent:"
+	},
+	"boto_vpc.route_table_present": {
+		"prefix": "boto_vpc.route_table_present:",
+		"body": [
+			"boto_vpc.route_table_present:",
+			"$0"
+		],
+		"description": "boto_vpc.route_table_present:"
+	},
+	"boto_vpc.subnet_absent": {
+		"prefix": "boto_vpc.subnet_absent:",
+		"body": [
+			"boto_vpc.subnet_absent:",
+			"$0"
+		],
+		"description": "boto_vpc.subnet_absent:"
+	},
+	"boto_vpc.subnet_present": {
+		"prefix": "boto_vpc.subnet_present:",
+		"body": [
+			"boto_vpc.subnet_present:",
+			"$0"
+		],
+		"description": "boto_vpc.subnet_present:"
+	},
+	"boto_vpc.vpc_peering_connection_absent": {
+		"prefix": "boto_vpc.vpc_peering_connection_absent:",
+		"body": [
+			"boto_vpc.vpc_peering_connection_absent:",
+			"$0"
+		],
+		"description": "boto_vpc.vpc_peering_connection_absent:"
+	},
+	"boto_vpc.vpc_peering_connection_present": {
+		"prefix": "boto_vpc.vpc_peering_connection_present:",
+		"body": [
+			"boto_vpc.vpc_peering_connection_present:",
+			"$0"
+		],
+		"description": "boto_vpc.vpc_peering_connection_present:"
+	}
+}

--- a/snippets/buildout.json
+++ b/snippets/buildout.json
@@ -1,0 +1,19 @@
+{
+	"buildout state": {
+		"prefix": [
+			"buildout."
+		],
+		"body": [
+			"buildout.${1|installed|}:"
+		],
+		"description": "buildout state"
+	},
+	"buildout.installed": {
+		"prefix": "buildout.installed:",
+		"body": [
+			"buildout.installed:",
+			"$0"
+		],
+		"description": "buildout.installed:"
+	}
+}

--- a/snippets/buildout.json
+++ b/snippets/buildout.json
@@ -1,13 +1,4 @@
 {
-	"buildout state": {
-		"prefix": [
-			"buildout."
-		],
-		"body": [
-			"buildout.${1|installed|}:"
-		],
-		"description": "buildout state"
-	},
 	"buildout.installed": {
 		"prefix": "buildout.installed:",
 		"body": [

--- a/snippets/ceph.json
+++ b/snippets/ceph.json
@@ -1,13 +1,4 @@
 {
-	"ceph state": {
-		"prefix": [
-			"ceph."
-		],
-		"body": [
-			"ceph.${1|quorum|}:"
-		],
-		"description": "ceph state"
-	},
 	"ceph.quorum": {
 		"prefix": "ceph.quorum:",
 		"body": [

--- a/snippets/ceph.json
+++ b/snippets/ceph.json
@@ -1,0 +1,19 @@
+{
+	"ceph state": {
+		"prefix": [
+			"ceph."
+		],
+		"body": [
+			"ceph.${1|quorum|}:"
+		],
+		"description": "ceph state"
+	},
+	"ceph.quorum": {
+		"prefix": "ceph.quorum:",
+		"body": [
+			"ceph.quorum:",
+			"$0"
+		],
+		"description": "ceph.quorum:"
+	}
+}

--- a/snippets/certutil.json
+++ b/snippets/certutil.json
@@ -1,0 +1,18 @@
+{
+	"certutil.del_store": {
+		"body": [
+			"certutil.del_store:",
+			"$0"
+		],
+		"prefix": "certutil.del_store:",
+		"description": "certutil.del_store:"
+	},
+	"certutil.add_store": {
+		"body": [
+			"certutil.add_store:",
+			"$0"
+		],
+		"prefix": "certutil.add_store:",
+		"description": "certutil.add_store:"
+	}
+}

--- a/snippets/chocolatey.json
+++ b/snippets/chocolatey.json
@@ -1,0 +1,26 @@
+{
+	"chocolatey.upgraded": {
+		"body": [
+			"chocolatey.upgraded:",
+			"$0"
+		],
+		"prefix": "chocolatey.upgraded:",
+		"description": "chocolatey.upgraded:"
+	},
+	"chocolatey.uninstalled": {
+		"body": [
+			"chocolatey.uninstalled:",
+			"$0"
+		],
+		"prefix": "chocolatey.uninstalled:",
+		"description": "chocolatey.uninstalled:"
+	},
+	"chocolatey.installed": {
+		"body": [
+			"chocolatey.installed:",
+			"$0"
+		],
+		"prefix": "chocolatey.installed:",
+		"description": "chocolatey.installed:"
+	}
+}

--- a/snippets/chronos_job.json
+++ b/snippets/chronos_job.json
@@ -1,13 +1,4 @@
 {
-	"chronos_job state": {
-		"prefix": [
-			"chronos_job."
-		],
-		"body": [
-			"chronos_job.${1|absent,config|}:"
-		],
-		"description": "chronos_job state"
-	},
 	"chronos_job.absent": {
 		"prefix": "chronos_job.absent:",
 		"body": [

--- a/snippets/chronos_job.json
+++ b/snippets/chronos_job.json
@@ -1,0 +1,27 @@
+{
+	"chronos_job state": {
+		"prefix": [
+			"chronos_job."
+		],
+		"body": [
+			"chronos_job.${1|absent,config|}:"
+		],
+		"description": "chronos_job state"
+	},
+	"chronos_job.absent": {
+		"prefix": "chronos_job.absent:",
+		"body": [
+			"chronos_job.absent:",
+			"$0"
+		],
+		"description": "chronos_job.absent:"
+	},
+	"chronos_job.config": {
+		"prefix": "chronos_job.config:",
+		"body": [
+			"chronos_job.config:",
+			"$0"
+		],
+		"description": "chronos_job.config:"
+	}
+}

--- a/snippets/cloud.json
+++ b/snippets/cloud.json
@@ -1,13 +1,4 @@
 {
-	"cloud state": {
-		"prefix": [
-			"cloud."
-		],
-		"body": [
-			"cloud.${1|absent,present,profile,volume_absent,volume_attached,volume_detached,volume_present|}:"
-		],
-		"description": "cloud state"
-	},
 	"cloud.absent": {
 		"prefix": "cloud.absent:",
 		"body": [

--- a/snippets/cloud.json
+++ b/snippets/cloud.json
@@ -1,0 +1,67 @@
+{
+	"cloud state": {
+		"prefix": [
+			"cloud."
+		],
+		"body": [
+			"cloud.${1|absent,present,profile,volume_absent,volume_attached,volume_detached,volume_present|}:"
+		],
+		"description": "cloud state"
+	},
+	"cloud.absent": {
+		"prefix": "cloud.absent:",
+		"body": [
+			"cloud.absent:",
+			"$0"
+		],
+		"description": "cloud.absent:"
+	},
+	"cloud.present": {
+		"prefix": "cloud.present:",
+		"body": [
+			"cloud.present:",
+			"$0"
+		],
+		"description": "cloud.present:"
+	},
+	"cloud.profile": {
+		"prefix": "cloud.profile:",
+		"body": [
+			"cloud.profile:",
+			"$0"
+		],
+		"description": "cloud.profile:"
+	},
+	"cloud.volume_absent": {
+		"prefix": "cloud.volume_absent:",
+		"body": [
+			"cloud.volume_absent:",
+			"$0"
+		],
+		"description": "cloud.volume_absent:"
+	},
+	"cloud.volume_attached": {
+		"prefix": "cloud.volume_attached:",
+		"body": [
+			"cloud.volume_attached:",
+			"$0"
+		],
+		"description": "cloud.volume_attached:"
+	},
+	"cloud.volume_detached": {
+		"prefix": "cloud.volume_detached:",
+		"body": [
+			"cloud.volume_detached:",
+			"$0"
+		],
+		"description": "cloud.volume_detached:"
+	},
+	"cloud.volume_present": {
+		"prefix": "cloud.volume_present:",
+		"body": [
+			"cloud.volume_present:",
+			"$0"
+		],
+		"description": "cloud.volume_present:"
+	}
+}

--- a/snippets/cmd.json
+++ b/snippets/cmd.json
@@ -1,13 +1,4 @@
 {
-	"cmd state": {
-		"prefix": [
-			"cmd."
-		],
-		"body": [
-			"cmd.${1|call,mod_run_check,run,script,wait,wait_call,wait_script,watch|}:"
-		],
-		"description": "cmd state"
-	},
 	"cmd.call": {
 		"prefix": "cmd.call:",
 		"body": [

--- a/snippets/cmd.json
+++ b/snippets/cmd.json
@@ -1,0 +1,75 @@
+{
+	"cmd state": {
+		"prefix": [
+			"cmd."
+		],
+		"body": [
+			"cmd.${1|call,mod_run_check,run,script,wait,wait_call,wait_script,watch|}:"
+		],
+		"description": "cmd state"
+	},
+	"cmd.call": {
+		"prefix": "cmd.call:",
+		"body": [
+			"cmd.call:",
+			"$0"
+		],
+		"description": "cmd.call:"
+	},
+	"cmd.mod_run_check": {
+		"prefix": "cmd.mod_run_check:",
+		"body": [
+			"cmd.mod_run_check:",
+			"$0"
+		],
+		"description": "cmd.mod_run_check:"
+	},
+	"cmd.run": {
+		"prefix": "cmd.run:",
+		"body": [
+			"cmd.run:",
+			"$0"
+		],
+		"description": "cmd.run:"
+	},
+	"cmd.script": {
+		"prefix": "cmd.script:",
+		"body": [
+			"cmd.script:",
+			"$0"
+		],
+		"description": "cmd.script:"
+	},
+	"cmd.wait": {
+		"prefix": "cmd.wait:",
+		"body": [
+			"cmd.wait:",
+			"$0"
+		],
+		"description": "cmd.wait:"
+	},
+	"cmd.wait_call": {
+		"prefix": "cmd.wait_call:",
+		"body": [
+			"cmd.wait_call:",
+			"$0"
+		],
+		"description": "cmd.wait_call:"
+	},
+	"cmd.wait_script": {
+		"prefix": "cmd.wait_script:",
+		"body": [
+			"cmd.wait_script:",
+			"$0"
+		],
+		"description": "cmd.wait_script:"
+	},
+	"cmd.watch": {
+		"prefix": "cmd.watch:",
+		"body": [
+			"cmd.watch:",
+			"$0"
+		],
+		"description": "cmd.watch:"
+	}
+}

--- a/snippets/composer.json
+++ b/snippets/composer.json
@@ -1,13 +1,4 @@
 {
-	"composer state": {
-		"prefix": [
-			"composer."
-		],
-		"body": [
-			"composer.${1|installed,update|}:"
-		],
-		"description": "composer state"
-	},
 	"composer.installed": {
 		"prefix": "composer.installed:",
 		"body": [

--- a/snippets/composer.json
+++ b/snippets/composer.json
@@ -1,0 +1,27 @@
+{
+	"composer state": {
+		"prefix": [
+			"composer."
+		],
+		"body": [
+			"composer.${1|installed,update|}:"
+		],
+		"description": "composer state"
+	},
+	"composer.installed": {
+		"prefix": "composer.installed:",
+		"body": [
+			"composer.installed:",
+			"$0"
+		],
+		"description": "composer.installed:"
+	},
+	"composer.update": {
+		"prefix": "composer.update:",
+		"body": [
+			"composer.update:",
+			"$0"
+		],
+		"description": "composer.update:"
+	}
+}

--- a/snippets/cron.json
+++ b/snippets/cron.json
@@ -1,0 +1,42 @@
+{
+	"cron.absent": {
+		"prefix": "cron.absent:",
+		"body": [
+			"cron.absent:",
+			"$0"
+		],
+		"description": "cron.absent:"
+	},
+	"cron.env_absent": {
+		"prefix": "cron.env_absent:",
+		"body": [
+			"cron.env_absent:",
+			"$0"
+		],
+		"description": "cron.env_absent:"
+	},
+	"cron.env_present": {
+		"prefix": "cron.env_present:",
+		"body": [
+			"cron.env_present:",
+			"$0"
+		],
+		"description": "cron.env_present:"
+	},
+	"cron.file": {
+		"prefix": "cron.file:",
+		"body": [
+			"cron.file:",
+			"$0"
+		],
+		"description": "cron.file:"
+	},
+	"cron.present": {
+		"prefix": "cron.present:",
+		"body": [
+			"cron.present:",
+			"$0"
+		],
+		"description": "cron.present:"
+	}
+}

--- a/snippets/cron.json
+++ b/snippets/cron.json
@@ -2,7 +2,10 @@
 	"cron.absent": {
 		"prefix": "cron.absent:",
 		"body": [
-			"cron.absent:",
+            "cron.absent:",
+            "\t- name: ${1:command}",
+            "\t- user: ${2:root}",
+            "\t- identifier: ${3:unique identifier}",
 			"$0"
 		],
 		"description": "cron.absent:"
@@ -10,7 +13,9 @@
 	"cron.env_absent": {
 		"prefix": "cron.env_absent:",
 		"body": [
-			"cron.env_absent:",
+            "cron.env_absent:",
+            "\t- name: ${1:env var}",
+            "\t- user: ${2:root}",
 			"$0"
 		],
 		"description": "cron.env_absent:"
@@ -18,7 +23,10 @@
 	"cron.env_present": {
 		"prefix": "cron.env_present:",
 		"body": [
-			"cron.env_present:",
+            "cron.env_present:",
+            "\t- name: ${1:env var}",
+            "\t- value: ${2:env var value}",
+            "\t- user: ${3:root}",
 			"$0"
 		],
 		"description": "cron.env_present:"
@@ -26,7 +34,9 @@
 	"cron.file": {
 		"prefix": "cron.file:",
 		"body": [
-			"cron.file:",
+            "cron.file:",
+            "\t- name: ${1:source file}",
+            "\t- user: ${2:root}",
 			"$0"
 		],
 		"description": "cron.file:"
@@ -34,7 +44,15 @@
 	"cron.present": {
 		"prefix": "cron.present:",
 		"body": [
-			"cron.present:",
+            "cron.present:",
+            "\t- name: ${1:command that should be executed}",
+            "\t- user: ${2:user}",
+            "\t- minute: ${3:*}",
+            "\t- hour: ${4:*}",
+            "\t- daymonth: ${5:*}",
+            "\t- month: ${6:*}",
+            "\t- dayweek: ${7:*}",
+            "\t- identifier: ${8:unique identifier}",
 			"$0"
 		],
 		"description": "cron.present:"

--- a/snippets/cryptdev.json
+++ b/snippets/cryptdev.json
@@ -1,0 +1,27 @@
+{
+	"cryptdev state": {
+		"prefix": [
+			"cryptdev."
+		],
+		"body": [
+			"cryptdev.${1|mapped,unmapped|}:"
+		],
+		"description": "cryptdev state"
+	},
+	"cryptdev.mapped": {
+		"prefix": "cryptdev.mapped:",
+		"body": [
+			"cryptdev.mapped:",
+			"$0"
+		],
+		"description": "cryptdev.mapped:"
+	},
+	"cryptdev.unmapped": {
+		"prefix": "cryptdev.unmapped:",
+		"body": [
+			"cryptdev.unmapped:",
+			"$0"
+		],
+		"description": "cryptdev.unmapped:"
+	}
+}

--- a/snippets/cryptdev.json
+++ b/snippets/cryptdev.json
@@ -1,13 +1,4 @@
 {
-	"cryptdev state": {
-		"prefix": [
-			"cryptdev."
-		],
-		"body": [
-			"cryptdev.${1|mapped,unmapped|}:"
-		],
-		"description": "cryptdev state"
-	},
 	"cryptdev.mapped": {
 		"prefix": "cryptdev.mapped:",
 		"body": [

--- a/snippets/csf.json
+++ b/snippets/csf.json
@@ -1,13 +1,4 @@
 {
-	"csf state": {
-		"prefix": [
-			"csf."
-		],
-		"body": [
-			"csf.${1|nics_skip,nics_skipped,option_present,ports_open,rule_absent,rule_present,testing_off,testing_on|}:"
-		],
-		"description": "csf state"
-	},
 	"csf.nics_skip": {
 		"prefix": "csf.nics_skip:",
 		"body": [

--- a/snippets/csf.json
+++ b/snippets/csf.json
@@ -1,0 +1,75 @@
+{
+	"csf state": {
+		"prefix": [
+			"csf."
+		],
+		"body": [
+			"csf.${1|nics_skip,nics_skipped,option_present,ports_open,rule_absent,rule_present,testing_off,testing_on|}:"
+		],
+		"description": "csf state"
+	},
+	"csf.nics_skip": {
+		"prefix": "csf.nics_skip:",
+		"body": [
+			"csf.nics_skip:",
+			"$0"
+		],
+		"description": "csf.nics_skip:"
+	},
+	"csf.nics_skipped": {
+		"prefix": "csf.nics_skipped:",
+		"body": [
+			"csf.nics_skipped:",
+			"$0"
+		],
+		"description": "csf.nics_skipped:"
+	},
+	"csf.option_present": {
+		"prefix": "csf.option_present:",
+		"body": [
+			"csf.option_present:",
+			"$0"
+		],
+		"description": "csf.option_present:"
+	},
+	"csf.ports_open": {
+		"prefix": "csf.ports_open:",
+		"body": [
+			"csf.ports_open:",
+			"$0"
+		],
+		"description": "csf.ports_open:"
+	},
+	"csf.rule_absent": {
+		"prefix": "csf.rule_absent:",
+		"body": [
+			"csf.rule_absent:",
+			"$0"
+		],
+		"description": "csf.rule_absent:"
+	},
+	"csf.rule_present": {
+		"prefix": "csf.rule_present:",
+		"body": [
+			"csf.rule_present:",
+			"$0"
+		],
+		"description": "csf.rule_present:"
+	},
+	"csf.testing_off": {
+		"prefix": "csf.testing_off:",
+		"body": [
+			"csf.testing_off:",
+			"$0"
+		],
+		"description": "csf.testing_off:"
+	},
+	"csf.testing_on": {
+		"prefix": "csf.testing_on:",
+		"body": [
+			"csf.testing_on:",
+			"$0"
+		],
+		"description": "csf.testing_on:"
+	}
+}

--- a/snippets/cyg.json
+++ b/snippets/cyg.json
@@ -1,0 +1,26 @@
+{
+	"cyg.removed": {
+		"body": [
+			"cyg.removed:",
+			"$0"
+		],
+		"prefix": "cyg.removed:",
+		"description": "cyg.removed:"
+	},
+	"cyg.installed": {
+		"body": [
+			"cyg.installed:",
+			"$0"
+		],
+		"prefix": "cyg.installed:",
+		"description": "cyg.installed:"
+	},
+	"cyg.updated": {
+		"body": [
+			"cyg.updated:",
+			"$0"
+		],
+		"prefix": "cyg.updated:",
+		"description": "cyg.updated:"
+	}
+}

--- a/snippets/ddns.json
+++ b/snippets/ddns.json
@@ -1,0 +1,18 @@
+{
+	"ddns.absent": {
+		"prefix": "ddns.absent:",
+		"body": [
+			"ddns.absent:",
+			"$0"
+		],
+		"description": "ddns.absent:"
+	},
+	"ddns.present": {
+		"prefix": "ddns.present:",
+		"body": [
+			"ddns.present:",
+			"$0"
+		],
+		"description": "ddns.present:"
+	}
+}

--- a/snippets/disk.json
+++ b/snippets/disk.json
@@ -1,13 +1,4 @@
 {
-	"disk state": {
-		"prefix": [
-			"disk."
-		],
-		"body": [
-			"disk.${1|status|}:"
-		],
-		"description": "disk state"
-	},
 	"disk.status": {
 		"prefix": "disk.status:",
 		"body": [

--- a/snippets/disk.json
+++ b/snippets/disk.json
@@ -1,0 +1,19 @@
+{
+	"disk state": {
+		"prefix": [
+			"disk."
+		],
+		"body": [
+			"disk.${1|status|}:"
+		],
+		"description": "disk state"
+	},
+	"disk.status": {
+		"prefix": "disk.status:",
+		"body": [
+			"disk.status:",
+			"$0"
+		],
+		"description": "disk.status:"
+	}
+}

--- a/snippets/dism.json
+++ b/snippets/dism.json
@@ -1,0 +1,50 @@
+{
+	"dism.package_installed": {
+		"body": [
+			"dism.package_installed:",
+			"$0"
+		],
+		"prefix": "dism.package_installed:",
+		"description": "dism.package_installed:"
+	},
+	"dism.capability_removed": {
+		"body": [
+			"dism.capability_removed:",
+			"$0"
+		],
+		"prefix": "dism.capability_removed:",
+		"description": "dism.capability_removed:"
+	},
+	"dism.feature_removed": {
+		"body": [
+			"dism.feature_removed:",
+			"$0"
+		],
+		"prefix": "dism.feature_removed:",
+		"description": "dism.feature_removed:"
+	},
+	"dism.capability_installed": {
+		"body": [
+			"dism.capability_installed:",
+			"$0"
+		],
+		"prefix": "dism.capability_installed:",
+		"description": "dism.capability_installed:"
+	},
+	"dism.package_removed": {
+		"body": [
+			"dism.package_removed:",
+			"$0"
+		],
+		"prefix": "dism.package_removed:",
+		"description": "dism.package_removed:"
+	},
+	"dism.feature_installed": {
+		"body": [
+			"dism.feature_installed:",
+			"$0"
+		],
+		"prefix": "dism.feature_installed:",
+		"description": "dism.feature_installed:"
+	}
+}

--- a/snippets/docker_container.json
+++ b/snippets/docker_container.json
@@ -1,0 +1,42 @@
+{
+	"docker_container.absent": {
+		"prefix": "docker_container.absent:",
+		"body": [
+			"docker_container.absent:",
+			"$0"
+		],
+		"description": "docker_container.absent:"
+	},
+	"docker_container.mod_run_check": {
+		"prefix": "docker_container.mod_run_check:",
+		"body": [
+			"docker_container.mod_run_check:",
+			"$0"
+		],
+		"description": "docker_container.mod_run_check:"
+	},
+	"docker_container.run": {
+		"prefix": "docker_container.run:",
+		"body": [
+			"docker_container.run:",
+			"$0"
+		],
+		"description": "docker_container.run:"
+	},
+	"docker_container.running": {
+		"prefix": "docker_container.running:",
+		"body": [
+			"docker_container.running:",
+			"$0"
+		],
+		"description": "docker_container.running:"
+	},
+	"docker_container.stopped": {
+		"prefix": "docker_container.stopped:",
+		"body": [
+			"docker_container.stopped:",
+			"$0"
+		],
+		"description": "docker_container.stopped:"
+	}
+}

--- a/snippets/docker_container.json
+++ b/snippets/docker_container.json
@@ -7,18 +7,12 @@
 		],
 		"description": "docker_container.absent:"
 	},
-	"docker_container.mod_run_check": {
-		"prefix": "docker_container.mod_run_check:",
-		"body": [
-			"docker_container.mod_run_check:",
-			"$0"
-		],
-		"description": "docker_container.mod_run_check:"
-	},
 	"docker_container.run": {
 		"prefix": "docker_container.run:",
 		"body": [
 			"docker_container.run:",
+			"\t- image: ${1:imagename}",
+			"\t- command: ${2:command name}",
 			"$0"
 		],
 		"description": "docker_container.run:"
@@ -27,6 +21,7 @@
 		"prefix": "docker_container.running:",
 		"body": [
 			"docker_container.running:",
+			"\t- image: ${1:imagename}",
 			"$0"
 		],
 		"description": "docker_container.running:"
@@ -35,6 +30,7 @@
 		"prefix": "docker_container.stopped:",
 		"body": [
 			"docker_container.stopped:",
+			"\t- name: ${1:name or id}",
 			"$0"
 		],
 		"description": "docker_container.stopped:"

--- a/snippets/docker_image.json
+++ b/snippets/docker_image.json
@@ -1,0 +1,18 @@
+{
+	"docker_image.absent": {
+		"prefix": "docker_image.absent:",
+		"body": [
+			"docker_image.absent:",
+			"$0"
+		],
+		"description": "docker_image.absent:"
+	},
+	"docker_image.present": {
+		"prefix": "docker_image.present:",
+		"body": [
+			"docker_image.present:",
+			"$0"
+		],
+		"description": "docker_image.present:"
+	}
+}

--- a/snippets/docker_image.json
+++ b/snippets/docker_image.json
@@ -11,6 +11,7 @@
 		"prefix": "docker_image.present:",
 		"body": [
 			"docker_image.present:",
+			"\t- tag: ${1:tag}",
 			"$0"
 		],
 		"description": "docker_image.present:"

--- a/snippets/docker_network.json
+++ b/snippets/docker_network.json
@@ -1,0 +1,18 @@
+{
+	"docker_network.absent": {
+		"prefix": "docker_network.absent:",
+		"body": [
+			"docker_network.absent:",
+			"$0"
+		],
+		"description": "docker_network.absent:"
+	},
+	"docker_network.present": {
+		"prefix": "docker_network.present:",
+		"body": [
+			"docker_network.present:",
+			"$0"
+		],
+		"description": "docker_network.present:"
+	}
+}

--- a/snippets/docker_volume.json
+++ b/snippets/docker_volume.json
@@ -1,0 +1,18 @@
+{
+	"docker_volume.absent": {
+		"prefix": "docker_volume.absent:",
+		"body": [
+			"docker_volume.absent:",
+			"$0"
+		],
+		"description": "docker_volume.absent:"
+	},
+	"docker_volume.present": {
+		"prefix": "docker_volume.present:",
+		"body": [
+			"docker_volume.present:",
+			"$0"
+		],
+		"description": "docker_volume.present:"
+	}
+}

--- a/snippets/dvs.json
+++ b/snippets/dvs.json
@@ -1,0 +1,34 @@
+{
+	"dvs.dvs_configured": {
+		"prefix": "dvs.dvs_configured:",
+		"body": [
+			"dvs.dvs_configured:",
+			"$0"
+		],
+		"description": "dvs.dvs_configured:"
+	},
+	"dvs.mod_init": {
+		"prefix": "dvs.mod_init:",
+		"body": [
+			"dvs.mod_init:",
+			"$0"
+		],
+		"description": "dvs.mod_init:"
+	},
+	"dvs.portgroups_configured": {
+		"prefix": "dvs.portgroups_configured:",
+		"body": [
+			"dvs.portgroups_configured:",
+			"$0"
+		],
+		"description": "dvs.portgroups_configured:"
+	},
+	"dvs.uplink_portgroup_configured": {
+		"prefix": "dvs.uplink_portgroup_configured:",
+		"body": [
+			"dvs.uplink_portgroup_configured:",
+			"$0"
+		],
+		"description": "dvs.uplink_portgroup_configured:"
+	}
+}

--- a/snippets/elasticsearch.json
+++ b/snippets/elasticsearch.json
@@ -1,0 +1,91 @@
+{
+	"elasticsearch state": {
+		"prefix": [
+			"elasticsearch."
+		],
+		"body": [
+			"elasticsearch.${1|alias_absent,alias_present,index_absent,index_present,index_template_absent,index_template_present,pipeline_absent,pipeline_present,search_template_absent,search_template_present|}:"
+		],
+		"description": "elasticsearch state"
+	},
+	"elasticsearch.alias_absent": {
+		"prefix": "elasticsearch.alias_absent:",
+		"body": [
+			"elasticsearch.alias_absent:",
+			"$0"
+		],
+		"description": "elasticsearch.alias_absent:"
+	},
+	"elasticsearch.alias_present": {
+		"prefix": "elasticsearch.alias_present:",
+		"body": [
+			"elasticsearch.alias_present:",
+			"$0"
+		],
+		"description": "elasticsearch.alias_present:"
+	},
+	"elasticsearch.index_absent": {
+		"prefix": "elasticsearch.index_absent:",
+		"body": [
+			"elasticsearch.index_absent:",
+			"$0"
+		],
+		"description": "elasticsearch.index_absent:"
+	},
+	"elasticsearch.index_present": {
+		"prefix": "elasticsearch.index_present:",
+		"body": [
+			"elasticsearch.index_present:",
+			"$0"
+		],
+		"description": "elasticsearch.index_present:"
+	},
+	"elasticsearch.index_template_absent": {
+		"prefix": "elasticsearch.index_template_absent:",
+		"body": [
+			"elasticsearch.index_template_absent:",
+			"$0"
+		],
+		"description": "elasticsearch.index_template_absent:"
+	},
+	"elasticsearch.index_template_present": {
+		"prefix": "elasticsearch.index_template_present:",
+		"body": [
+			"elasticsearch.index_template_present:",
+			"$0"
+		],
+		"description": "elasticsearch.index_template_present:"
+	},
+	"elasticsearch.pipeline_absent": {
+		"prefix": "elasticsearch.pipeline_absent:",
+		"body": [
+			"elasticsearch.pipeline_absent:",
+			"$0"
+		],
+		"description": "elasticsearch.pipeline_absent:"
+	},
+	"elasticsearch.pipeline_present": {
+		"prefix": "elasticsearch.pipeline_present:",
+		"body": [
+			"elasticsearch.pipeline_present:",
+			"$0"
+		],
+		"description": "elasticsearch.pipeline_present:"
+	},
+	"elasticsearch.search_template_absent": {
+		"prefix": "elasticsearch.search_template_absent:",
+		"body": [
+			"elasticsearch.search_template_absent:",
+			"$0"
+		],
+		"description": "elasticsearch.search_template_absent:"
+	},
+	"elasticsearch.search_template_present": {
+		"prefix": "elasticsearch.search_template_present:",
+		"body": [
+			"elasticsearch.search_template_present:",
+			"$0"
+		],
+		"description": "elasticsearch.search_template_present:"
+	}
+}

--- a/snippets/elasticsearch.json
+++ b/snippets/elasticsearch.json
@@ -1,13 +1,4 @@
 {
-	"elasticsearch state": {
-		"prefix": [
-			"elasticsearch."
-		],
-		"body": [
-			"elasticsearch.${1|alias_absent,alias_present,index_absent,index_present,index_template_absent,index_template_present,pipeline_absent,pipeline_present,search_template_absent,search_template_present|}:"
-		],
-		"description": "elasticsearch state"
-	},
 	"elasticsearch.alias_absent": {
 		"prefix": "elasticsearch.alias_absent:",
 		"body": [

--- a/snippets/elasticsearch_index.json
+++ b/snippets/elasticsearch_index.json
@@ -1,13 +1,4 @@
 {
-	"elasticsearch_index state": {
-		"prefix": [
-			"elasticsearch_index."
-		],
-		"body": [
-			"elasticsearch_index.${1|absent,present|}:"
-		],
-		"description": "elasticsearch_index state"
-	},
 	"elasticsearch_index.absent": {
 		"prefix": "elasticsearch_index.absent:",
 		"body": [

--- a/snippets/elasticsearch_index.json
+++ b/snippets/elasticsearch_index.json
@@ -1,0 +1,27 @@
+{
+	"elasticsearch_index state": {
+		"prefix": [
+			"elasticsearch_index."
+		],
+		"body": [
+			"elasticsearch_index.${1|absent,present|}:"
+		],
+		"description": "elasticsearch_index state"
+	},
+	"elasticsearch_index.absent": {
+		"prefix": "elasticsearch_index.absent:",
+		"body": [
+			"elasticsearch_index.absent:",
+			"$0"
+		],
+		"description": "elasticsearch_index.absent:"
+	},
+	"elasticsearch_index.present": {
+		"prefix": "elasticsearch_index.present:",
+		"body": [
+			"elasticsearch_index.present:",
+			"$0"
+		],
+		"description": "elasticsearch_index.present:"
+	}
+}

--- a/snippets/elasticsearch_index_template.json
+++ b/snippets/elasticsearch_index_template.json
@@ -1,13 +1,4 @@
 {
-	"elasticsearch_index_template state": {
-		"prefix": [
-			"elasticsearch_index_template."
-		],
-		"body": [
-			"elasticsearch_index_template.${1|absent,present|}:"
-		],
-		"description": "elasticsearch_index_template state"
-	},
 	"elasticsearch_index_template.absent": {
 		"prefix": "elasticsearch_index_template.absent:",
 		"body": [

--- a/snippets/elasticsearch_index_template.json
+++ b/snippets/elasticsearch_index_template.json
@@ -1,0 +1,27 @@
+{
+	"elasticsearch_index_template state": {
+		"prefix": [
+			"elasticsearch_index_template."
+		],
+		"body": [
+			"elasticsearch_index_template.${1|absent,present|}:"
+		],
+		"description": "elasticsearch_index_template state"
+	},
+	"elasticsearch_index_template.absent": {
+		"prefix": "elasticsearch_index_template.absent:",
+		"body": [
+			"elasticsearch_index_template.absent:",
+			"$0"
+		],
+		"description": "elasticsearch_index_template.absent:"
+	},
+	"elasticsearch_index_template.present": {
+		"prefix": "elasticsearch_index_template.present:",
+		"body": [
+			"elasticsearch_index_template.present:",
+			"$0"
+		],
+		"description": "elasticsearch_index_template.present:"
+	}
+}

--- a/snippets/environ.json
+++ b/snippets/environ.json
@@ -1,13 +1,4 @@
 {
-	"environ state": {
-		"prefix": [
-			"environ."
-		],
-		"body": [
-			"environ.${1|setenv|}:"
-		],
-		"description": "environ state"
-	},
 	"environ.setenv": {
 		"prefix": "environ.setenv:",
 		"body": [

--- a/snippets/environ.json
+++ b/snippets/environ.json
@@ -1,0 +1,19 @@
+{
+	"environ state": {
+		"prefix": [
+			"environ."
+		],
+		"body": [
+			"environ.${1|setenv|}:"
+		],
+		"description": "environ state"
+	},
+	"environ.setenv": {
+		"prefix": "environ.setenv:",
+		"body": [
+			"environ.setenv:",
+			"$0"
+		],
+		"description": "environ.setenv:"
+	}
+}

--- a/snippets/esxdatacenter.json
+++ b/snippets/esxdatacenter.json
@@ -1,13 +1,4 @@
 {
-	"esxdatacenter state": {
-		"prefix": [
-			"esxdatacenter."
-		],
-		"body": [
-			"esxdatacenter.${1|datacenter_configured,mod_init|}:"
-		],
-		"description": "esxdatacenter state"
-	},
 	"esxdatacenter.datacenter_configured": {
 		"prefix": "esxdatacenter.datacenter_configured:",
 		"body": [

--- a/snippets/esxdatacenter.json
+++ b/snippets/esxdatacenter.json
@@ -1,0 +1,27 @@
+{
+	"esxdatacenter state": {
+		"prefix": [
+			"esxdatacenter."
+		],
+		"body": [
+			"esxdatacenter.${1|datacenter_configured,mod_init|}:"
+		],
+		"description": "esxdatacenter state"
+	},
+	"esxdatacenter.datacenter_configured": {
+		"prefix": "esxdatacenter.datacenter_configured:",
+		"body": [
+			"esxdatacenter.datacenter_configured:",
+			"$0"
+		],
+		"description": "esxdatacenter.datacenter_configured:"
+	},
+	"esxdatacenter.mod_init": {
+		"prefix": "esxdatacenter.mod_init:",
+		"body": [
+			"esxdatacenter.mod_init:",
+			"$0"
+		],
+		"description": "esxdatacenter.mod_init:"
+	}
+}

--- a/snippets/etcd.json
+++ b/snippets/etcd.json
@@ -1,0 +1,51 @@
+{
+	"etcd state": {
+		"prefix": [
+			"etcd."
+		],
+		"body": [
+			"etcd.${1|directory,rm,set,wait_rm,wait_set|}:"
+		],
+		"description": "etcd state"
+	},
+	"etcd.directory": {
+		"prefix": "etcd.directory:",
+		"body": [
+			"etcd.directory:",
+			"$0"
+		],
+		"description": "etcd.directory:"
+	},
+	"etcd.rm": {
+		"prefix": "etcd.rm:",
+		"body": [
+			"etcd.rm:",
+			"$0"
+		],
+		"description": "etcd.rm:"
+	},
+	"etcd.set": {
+		"prefix": "etcd.set:",
+		"body": [
+			"etcd.set:",
+			"$0"
+		],
+		"description": "etcd.set:"
+	},
+	"etcd.wait_rm": {
+		"prefix": "etcd.wait_rm:",
+		"body": [
+			"etcd.wait_rm:",
+			"$0"
+		],
+		"description": "etcd.wait_rm:"
+	},
+	"etcd.wait_set": {
+		"prefix": "etcd.wait_set:",
+		"body": [
+			"etcd.wait_set:",
+			"$0"
+		],
+		"description": "etcd.wait_set:"
+	}
+}

--- a/snippets/etcd.json
+++ b/snippets/etcd.json
@@ -1,13 +1,4 @@
 {
-	"etcd state": {
-		"prefix": [
-			"etcd."
-		],
-		"body": [
-			"etcd.${1|directory,rm,set,wait_rm,wait_set|}:"
-		],
-		"description": "etcd state"
-	},
 	"etcd.directory": {
 		"prefix": "etcd.directory:",
 		"body": [

--- a/snippets/ethtool.json
+++ b/snippets/ethtool.json
@@ -1,0 +1,35 @@
+{
+	"ethtool state": {
+		"prefix": [
+			"ethtool."
+		],
+		"body": [
+			"ethtool.${1|coalesce,offload,ring|}:"
+		],
+		"description": "ethtool state"
+	},
+	"ethtool.coalesce": {
+		"prefix": "ethtool.coalesce:",
+		"body": [
+			"ethtool.coalesce:",
+			"$0"
+		],
+		"description": "ethtool.coalesce:"
+	},
+	"ethtool.offload": {
+		"prefix": "ethtool.offload:",
+		"body": [
+			"ethtool.offload:",
+			"$0"
+		],
+		"description": "ethtool.offload:"
+	},
+	"ethtool.ring": {
+		"prefix": "ethtool.ring:",
+		"body": [
+			"ethtool.ring:",
+			"$0"
+		],
+		"description": "ethtool.ring:"
+	}
+}

--- a/snippets/ethtool.json
+++ b/snippets/ethtool.json
@@ -1,13 +1,4 @@
 {
-	"ethtool state": {
-		"prefix": [
-			"ethtool."
-		],
-		"body": [
-			"ethtool.${1|coalesce,offload,ring|}:"
-		],
-		"description": "ethtool state"
-	},
 	"ethtool.coalesce": {
 		"prefix": "ethtool.coalesce:",
 		"body": [

--- a/snippets/event.json
+++ b/snippets/event.json
@@ -1,13 +1,4 @@
 {
-	"event state": {
-		"prefix": [
-			"event."
-		],
-		"body": [
-			"event.${1|fire_master,send,wait|}:"
-		],
-		"description": "event state"
-	},
 	"event.fire_master": {
 		"prefix": "event.fire_master:",
 		"body": [

--- a/snippets/event.json
+++ b/snippets/event.json
@@ -1,0 +1,35 @@
+{
+	"event state": {
+		"prefix": [
+			"event."
+		],
+		"body": [
+			"event.${1|fire_master,send,wait|}:"
+		],
+		"description": "event state"
+	},
+	"event.fire_master": {
+		"prefix": "event.fire_master:",
+		"body": [
+			"event.fire_master:",
+			"$0"
+		],
+		"description": "event.fire_master:"
+	},
+	"event.send": {
+		"prefix": "event.send:",
+		"body": [
+			"event.send:",
+			"$0"
+		],
+		"description": "event.send:"
+	},
+	"event.wait": {
+		"prefix": "event.wait:",
+		"body": [
+			"event.wait:",
+			"$0"
+		],
+		"description": "event.wait:"
+	}
+}

--- a/snippets/file.json
+++ b/snippets/file.json
@@ -118,9 +118,21 @@
 		"prefix": "file.managed:",
 		"body": [
 			"file.managed:",
-			"$0"
+			"\t- $0"
 		],
 		"description": "file.managed:"
+	},
+	"file.managed (salt source)": {
+		"prefix": "file.managed:",
+		"body": [
+			"file.managed:",
+			"\t- source: salt://${1:source}",
+			"\t- user: ${2:root}",
+			"\t- group: ${3:root}",
+			"\t- mode: ${4:644}",
+			"$0"
+		],
+		"description": "file.managed with a salt:// based source"
 	},
 	"file.missing": {
 		"prefix": "file.missing:",

--- a/snippets/file.json
+++ b/snippets/file.json
@@ -1,0 +1,243 @@
+{
+	"file state": {
+		"prefix": [
+			"file."
+		],
+		"body": [
+			"file.${1|absent,accumulated,append,blockreplace,cached,comment,copy,decode,directory,exists,hardlink,line,managed,missing,mknod,mod_run_check_cmd,not_cached,patch,prepend,recurse,rename,replace,retention_schedule,serialize,shortcut,symlink,tidied,touch,uncomment|}:"
+		],
+		"description": "file state"
+	},
+	"file.absent": {
+		"prefix": "file.absent:",
+		"body": [
+			"file.absent:",
+			"$0"
+		],
+		"description": "file.absent:"
+	},
+	"file.accumulated": {
+		"prefix": "file.accumulated:",
+		"body": [
+			"file.accumulated:",
+			"$0"
+		],
+		"description": "file.accumulated:"
+	},
+	"file.append": {
+		"prefix": "file.append:",
+		"body": [
+			"file.append:",
+			"$0"
+		],
+		"description": "file.append:"
+	},
+	"file.blockreplace": {
+		"prefix": "file.blockreplace:",
+		"body": [
+			"file.blockreplace:",
+			"$0"
+		],
+		"description": "file.blockreplace:"
+	},
+	"file.cached": {
+		"prefix": "file.cached:",
+		"body": [
+			"file.cached:",
+			"$0"
+		],
+		"description": "file.cached:"
+	},
+	"file.comment": {
+		"prefix": "file.comment:",
+		"body": [
+			"file.comment:",
+			"$0"
+		],
+		"description": "file.comment:"
+	},
+	"file.copy": {
+		"prefix": "file.copy:",
+		"body": [
+			"file.copy:",
+			"$0"
+		],
+		"description": "file.copy:"
+	},
+	"file.decode": {
+		"prefix": "file.decode:",
+		"body": [
+			"file.decode:",
+			"$0"
+		],
+		"description": "file.decode:"
+	},
+	"file.directory": {
+		"prefix": "file.directory:",
+		"body": [
+			"file.directory:",
+			"$0"
+		],
+		"description": "file.directory:"
+	},
+	"file.exists": {
+		"prefix": "file.exists:",
+		"body": [
+			"file.exists:",
+			"$0"
+		],
+		"description": "file.exists:"
+	},
+	"file.hardlink": {
+		"prefix": "file.hardlink:",
+		"body": [
+			"file.hardlink:",
+			"$0"
+		],
+		"description": "file.hardlink:"
+	},
+	"file.line": {
+		"prefix": "file.line:",
+		"body": [
+			"file.line:",
+			"$0"
+		],
+		"description": "file.line:"
+	},
+	"file.managed": {
+		"prefix": "file.managed:",
+		"body": [
+			"file.managed:",
+			"$0"
+		],
+		"description": "file.managed:"
+	},
+	"file.missing": {
+		"prefix": "file.missing:",
+		"body": [
+			"file.missing:",
+			"$0"
+		],
+		"description": "file.missing:"
+	},
+	"file.mknod": {
+		"prefix": "file.mknod:",
+		"body": [
+			"file.mknod:",
+			"$0"
+		],
+		"description": "file.mknod:"
+	},
+	"file.mod_run_check_cmd": {
+		"prefix": "file.mod_run_check_cmd:",
+		"body": [
+			"file.mod_run_check_cmd:",
+			"$0"
+		],
+		"description": "file.mod_run_check_cmd:"
+	},
+	"file.not_cached": {
+		"prefix": "file.not_cached:",
+		"body": [
+			"file.not_cached:",
+			"$0"
+		],
+		"description": "file.not_cached:"
+	},
+	"file.patch": {
+		"prefix": "file.patch:",
+		"body": [
+			"file.patch:",
+			"$0"
+		],
+		"description": "file.patch:"
+	},
+	"file.prepend": {
+		"prefix": "file.prepend:",
+		"body": [
+			"file.prepend:",
+			"$0"
+		],
+		"description": "file.prepend:"
+	},
+	"file.recurse": {
+		"prefix": "file.recurse:",
+		"body": [
+			"file.recurse:",
+			"$0"
+		],
+		"description": "file.recurse:"
+	},
+	"file.rename": {
+		"prefix": "file.rename:",
+		"body": [
+			"file.rename:",
+			"$0"
+		],
+		"description": "file.rename:"
+	},
+	"file.replace": {
+		"prefix": "file.replace:",
+		"body": [
+			"file.replace:",
+			"$0"
+		],
+		"description": "file.replace:"
+	},
+	"file.retention_schedule": {
+		"prefix": "file.retention_schedule:",
+		"body": [
+			"file.retention_schedule:",
+			"$0"
+		],
+		"description": "file.retention_schedule:"
+	},
+	"file.serialize": {
+		"prefix": "file.serialize:",
+		"body": [
+			"file.serialize:",
+			"$0"
+		],
+		"description": "file.serialize:"
+	},
+	"file.shortcut": {
+		"prefix": "file.shortcut:",
+		"body": [
+			"file.shortcut:",
+			"$0"
+		],
+		"description": "file.shortcut:"
+	},
+	"file.symlink": {
+		"prefix": "file.symlink:",
+		"body": [
+			"file.symlink:",
+			"$0"
+		],
+		"description": "file.symlink:"
+	},
+	"file.tidied": {
+		"prefix": "file.tidied:",
+		"body": [
+			"file.tidied:",
+			"$0"
+		],
+		"description": "file.tidied:"
+	},
+	"file.touch": {
+		"prefix": "file.touch:",
+		"body": [
+			"file.touch:",
+			"$0"
+		],
+		"description": "file.touch:"
+	},
+	"file.uncomment": {
+		"prefix": "file.uncomment:",
+		"body": [
+			"file.uncomment:",
+			"$0"
+		],
+		"description": "file.uncomment:"
+	}
+}

--- a/snippets/file.json
+++ b/snippets/file.json
@@ -1,13 +1,4 @@
 {
-	"file state": {
-		"prefix": [
-			"file."
-		],
-		"body": [
-			"file.${1|absent,accumulated,append,blockreplace,cached,comment,copy,decode,directory,exists,hardlink,line,managed,missing,mknod,mod_run_check_cmd,not_cached,patch,prepend,recurse,rename,replace,retention_schedule,serialize,shortcut,symlink,tidied,touch,uncomment|}:"
-		],
-		"description": "file state"
-	},
 	"file.absent": {
 		"prefix": "file.absent:",
 		"body": [

--- a/snippets/firewall.json
+++ b/snippets/firewall.json
@@ -1,0 +1,19 @@
+{
+	"firewall state": {
+		"prefix": [
+			"firewall."
+		],
+		"body": [
+			"firewall.${1|check|}:"
+		],
+		"description": "firewall state"
+	},
+	"firewall.check": {
+		"prefix": "firewall.check:",
+		"body": [
+			"firewall.check:",
+			"$0"
+		],
+		"description": "firewall.check:"
+	}
+}

--- a/snippets/firewall.json
+++ b/snippets/firewall.json
@@ -1,13 +1,4 @@
 {
-	"firewall state": {
-		"prefix": [
-			"firewall."
-		],
-		"body": [
-			"firewall.${1|check|}:"
-		],
-		"description": "firewall state"
-	},
 	"firewall.check": {
 		"prefix": "firewall.check:",
 		"body": [

--- a/snippets/gem.json
+++ b/snippets/gem.json
@@ -1,13 +1,4 @@
 {
-	"gem state": {
-		"prefix": [
-			"gem."
-		],
-		"body": [
-			"gem.${1|installed,removed,sources_add,sources_remove|}:"
-		],
-		"description": "gem state"
-	},
 	"gem.installed": {
 		"prefix": "gem.installed:",
 		"body": [

--- a/snippets/gem.json
+++ b/snippets/gem.json
@@ -1,0 +1,43 @@
+{
+	"gem state": {
+		"prefix": [
+			"gem."
+		],
+		"body": [
+			"gem.${1|installed,removed,sources_add,sources_remove|}:"
+		],
+		"description": "gem state"
+	},
+	"gem.installed": {
+		"prefix": "gem.installed:",
+		"body": [
+			"gem.installed:",
+			"$0"
+		],
+		"description": "gem.installed:"
+	},
+	"gem.removed": {
+		"prefix": "gem.removed:",
+		"body": [
+			"gem.removed:",
+			"$0"
+		],
+		"description": "gem.removed:"
+	},
+	"gem.sources_add": {
+		"prefix": "gem.sources_add:",
+		"body": [
+			"gem.sources_add:",
+			"$0"
+		],
+		"description": "gem.sources_add:"
+	},
+	"gem.sources_remove": {
+		"prefix": "gem.sources_remove:",
+		"body": [
+			"gem.sources_remove:",
+			"$0"
+		],
+		"description": "gem.sources_remove:"
+	}
+}

--- a/snippets/git.json
+++ b/snippets/git.json
@@ -1,13 +1,4 @@
 {
-	"git state": {
-		"prefix": [
-			"git."
-		],
-		"body": [
-			"git.${1|cloned,config_set,config_unset,detached,latest,mod_run_check,present|}:"
-		],
-		"description": "git state"
-	},
 	"git.cloned": {
 		"prefix": "git.cloned:",
 		"body": [

--- a/snippets/git.json
+++ b/snippets/git.json
@@ -1,0 +1,67 @@
+{
+	"git state": {
+		"prefix": [
+			"git."
+		],
+		"body": [
+			"git.${1|cloned,config_set,config_unset,detached,latest,mod_run_check,present|}:"
+		],
+		"description": "git state"
+	},
+	"git.cloned": {
+		"prefix": "git.cloned:",
+		"body": [
+			"git.cloned:",
+			"$0"
+		],
+		"description": "git.cloned:"
+	},
+	"git.config_set": {
+		"prefix": "git.config_set:",
+		"body": [
+			"git.config_set:",
+			"$0"
+		],
+		"description": "git.config_set:"
+	},
+	"git.config_unset": {
+		"prefix": "git.config_unset:",
+		"body": [
+			"git.config_unset:",
+			"$0"
+		],
+		"description": "git.config_unset:"
+	},
+	"git.detached": {
+		"prefix": "git.detached:",
+		"body": [
+			"git.detached:",
+			"$0"
+		],
+		"description": "git.detached:"
+	},
+	"git.latest": {
+		"prefix": "git.latest:",
+		"body": [
+			"git.latest:",
+			"$0"
+		],
+		"description": "git.latest:"
+	},
+	"git.mod_run_check": {
+		"prefix": "git.mod_run_check:",
+		"body": [
+			"git.mod_run_check:",
+			"$0"
+		],
+		"description": "git.mod_run_check:"
+	},
+	"git.present": {
+		"prefix": "git.present:",
+		"body": [
+			"git.present:",
+			"$0"
+		],
+		"description": "git.present:"
+	}
+}

--- a/snippets/glassfish.json
+++ b/snippets/glassfish.json
@@ -1,0 +1,75 @@
+{
+	"glassfish state": {
+		"prefix": [
+			"glassfish."
+		],
+		"body": [
+			"glassfish.${1|connection_factory_absent,connection_factory_present,destination_absent,destination_present,jdbc_datasource_absent,jdbc_datasource_present,system_properties_absent,system_properties_present|}:"
+		],
+		"description": "glassfish state"
+	},
+	"glassfish.connection_factory_absent": {
+		"prefix": "glassfish.connection_factory_absent:",
+		"body": [
+			"glassfish.connection_factory_absent:",
+			"$0"
+		],
+		"description": "glassfish.connection_factory_absent:"
+	},
+	"glassfish.connection_factory_present": {
+		"prefix": "glassfish.connection_factory_present:",
+		"body": [
+			"glassfish.connection_factory_present:",
+			"$0"
+		],
+		"description": "glassfish.connection_factory_present:"
+	},
+	"glassfish.destination_absent": {
+		"prefix": "glassfish.destination_absent:",
+		"body": [
+			"glassfish.destination_absent:",
+			"$0"
+		],
+		"description": "glassfish.destination_absent:"
+	},
+	"glassfish.destination_present": {
+		"prefix": "glassfish.destination_present:",
+		"body": [
+			"glassfish.destination_present:",
+			"$0"
+		],
+		"description": "glassfish.destination_present:"
+	},
+	"glassfish.jdbc_datasource_absent": {
+		"prefix": "glassfish.jdbc_datasource_absent:",
+		"body": [
+			"glassfish.jdbc_datasource_absent:",
+			"$0"
+		],
+		"description": "glassfish.jdbc_datasource_absent:"
+	},
+	"glassfish.jdbc_datasource_present": {
+		"prefix": "glassfish.jdbc_datasource_present:",
+		"body": [
+			"glassfish.jdbc_datasource_present:",
+			"$0"
+		],
+		"description": "glassfish.jdbc_datasource_present:"
+	},
+	"glassfish.system_properties_absent": {
+		"prefix": "glassfish.system_properties_absent:",
+		"body": [
+			"glassfish.system_properties_absent:",
+			"$0"
+		],
+		"description": "glassfish.system_properties_absent:"
+	},
+	"glassfish.system_properties_present": {
+		"prefix": "glassfish.system_properties_present:",
+		"body": [
+			"glassfish.system_properties_present:",
+			"$0"
+		],
+		"description": "glassfish.system_properties_present:"
+	}
+}

--- a/snippets/glassfish.json
+++ b/snippets/glassfish.json
@@ -1,13 +1,4 @@
 {
-	"glassfish state": {
-		"prefix": [
-			"glassfish."
-		],
-		"body": [
-			"glassfish.${1|connection_factory_absent,connection_factory_present,destination_absent,destination_present,jdbc_datasource_absent,jdbc_datasource_present,system_properties_absent,system_properties_present|}:"
-		],
-		"description": "glassfish state"
-	},
 	"glassfish.connection_factory_absent": {
 		"prefix": "glassfish.connection_factory_absent:",
 		"body": [

--- a/snippets/gnomedesktop.json
+++ b/snippets/gnomedesktop.json
@@ -1,13 +1,4 @@
 {
-	"gnomedesktop state": {
-		"prefix": [
-			"gnomedesktop."
-		],
-		"body": [
-			"gnomedesktop.${1|desktop_interface,desktop_lockdown,wm_preferences|}:"
-		],
-		"description": "gnomedesktop state"
-	},
 	"gnomedesktop.desktop_interface": {
 		"prefix": "gnomedesktop.desktop_interface:",
 		"body": [

--- a/snippets/gnomedesktop.json
+++ b/snippets/gnomedesktop.json
@@ -1,0 +1,35 @@
+{
+	"gnomedesktop state": {
+		"prefix": [
+			"gnomedesktop."
+		],
+		"body": [
+			"gnomedesktop.${1|desktop_interface,desktop_lockdown,wm_preferences|}:"
+		],
+		"description": "gnomedesktop state"
+	},
+	"gnomedesktop.desktop_interface": {
+		"prefix": "gnomedesktop.desktop_interface:",
+		"body": [
+			"gnomedesktop.desktop_interface:",
+			"$0"
+		],
+		"description": "gnomedesktop.desktop_interface:"
+	},
+	"gnomedesktop.desktop_lockdown": {
+		"prefix": "gnomedesktop.desktop_lockdown:",
+		"body": [
+			"gnomedesktop.desktop_lockdown:",
+			"$0"
+		],
+		"description": "gnomedesktop.desktop_lockdown:"
+	},
+	"gnomedesktop.wm_preferences": {
+		"prefix": "gnomedesktop.wm_preferences:",
+		"body": [
+			"gnomedesktop.wm_preferences:",
+			"$0"
+		],
+		"description": "gnomedesktop.wm_preferences:"
+	}
+}

--- a/snippets/gpg.json
+++ b/snippets/gpg.json
@@ -1,0 +1,27 @@
+{
+	"gpg state": {
+		"prefix": [
+			"gpg."
+		],
+		"body": [
+			"gpg.${1|absent,present|}:"
+		],
+		"description": "gpg state"
+	},
+	"gpg.absent": {
+		"prefix": "gpg.absent:",
+		"body": [
+			"gpg.absent:",
+			"$0"
+		],
+		"description": "gpg.absent:"
+	},
+	"gpg.present": {
+		"prefix": "gpg.present:",
+		"body": [
+			"gpg.present:",
+			"$0"
+		],
+		"description": "gpg.present:"
+	}
+}

--- a/snippets/gpg.json
+++ b/snippets/gpg.json
@@ -1,13 +1,4 @@
 {
-	"gpg state": {
-		"prefix": [
-			"gpg."
-		],
-		"body": [
-			"gpg.${1|absent,present|}:"
-		],
-		"description": "gpg state"
-	},
 	"gpg.absent": {
 		"prefix": "gpg.absent:",
 		"body": [

--- a/snippets/grafana4_dashboard.json
+++ b/snippets/grafana4_dashboard.json
@@ -1,0 +1,27 @@
+{
+	"grafana4_dashboard state": {
+		"prefix": [
+			"grafana4_dashboard."
+		],
+		"body": [
+			"grafana4_dashboard.${1|absent,present|}:"
+		],
+		"description": "grafana4_dashboard state"
+	},
+	"grafana4_dashboard.absent": {
+		"prefix": "grafana4_dashboard.absent:",
+		"body": [
+			"grafana4_dashboard.absent:",
+			"$0"
+		],
+		"description": "grafana4_dashboard.absent:"
+	},
+	"grafana4_dashboard.present": {
+		"prefix": "grafana4_dashboard.present:",
+		"body": [
+			"grafana4_dashboard.present:",
+			"$0"
+		],
+		"description": "grafana4_dashboard.present:"
+	}
+}

--- a/snippets/grafana4_dashboard.json
+++ b/snippets/grafana4_dashboard.json
@@ -1,13 +1,4 @@
 {
-	"grafana4_dashboard state": {
-		"prefix": [
-			"grafana4_dashboard."
-		],
-		"body": [
-			"grafana4_dashboard.${1|absent,present|}:"
-		],
-		"description": "grafana4_dashboard state"
-	},
 	"grafana4_dashboard.absent": {
 		"prefix": "grafana4_dashboard.absent:",
 		"body": [

--- a/snippets/grafana4_datasource.json
+++ b/snippets/grafana4_datasource.json
@@ -1,13 +1,4 @@
 {
-	"grafana4_datasource state": {
-		"prefix": [
-			"grafana4_datasource."
-		],
-		"body": [
-			"grafana4_datasource.${1|absent,deep_diff,present|}:"
-		],
-		"description": "grafana4_datasource state"
-	},
 	"grafana4_datasource.absent": {
 		"prefix": "grafana4_datasource.absent:",
 		"body": [

--- a/snippets/grafana4_datasource.json
+++ b/snippets/grafana4_datasource.json
@@ -1,0 +1,35 @@
+{
+	"grafana4_datasource state": {
+		"prefix": [
+			"grafana4_datasource."
+		],
+		"body": [
+			"grafana4_datasource.${1|absent,deep_diff,present|}:"
+		],
+		"description": "grafana4_datasource state"
+	},
+	"grafana4_datasource.absent": {
+		"prefix": "grafana4_datasource.absent:",
+		"body": [
+			"grafana4_datasource.absent:",
+			"$0"
+		],
+		"description": "grafana4_datasource.absent:"
+	},
+	"grafana4_datasource.deep_diff": {
+		"prefix": "grafana4_datasource.deep_diff:",
+		"body": [
+			"grafana4_datasource.deep_diff:",
+			"$0"
+		],
+		"description": "grafana4_datasource.deep_diff:"
+	},
+	"grafana4_datasource.present": {
+		"prefix": "grafana4_datasource.present:",
+		"body": [
+			"grafana4_datasource.present:",
+			"$0"
+		],
+		"description": "grafana4_datasource.present:"
+	}
+}

--- a/snippets/grafana4_org.json
+++ b/snippets/grafana4_org.json
@@ -1,0 +1,35 @@
+{
+	"grafana4_org state": {
+		"prefix": [
+			"grafana4_org."
+		],
+		"body": [
+			"grafana4_org.${1|absent,deep_diff,present|}:"
+		],
+		"description": "grafana4_org state"
+	},
+	"grafana4_org.absent": {
+		"prefix": "grafana4_org.absent:",
+		"body": [
+			"grafana4_org.absent:",
+			"$0"
+		],
+		"description": "grafana4_org.absent:"
+	},
+	"grafana4_org.deep_diff": {
+		"prefix": "grafana4_org.deep_diff:",
+		"body": [
+			"grafana4_org.deep_diff:",
+			"$0"
+		],
+		"description": "grafana4_org.deep_diff:"
+	},
+	"grafana4_org.present": {
+		"prefix": "grafana4_org.present:",
+		"body": [
+			"grafana4_org.present:",
+			"$0"
+		],
+		"description": "grafana4_org.present:"
+	}
+}

--- a/snippets/grafana4_org.json
+++ b/snippets/grafana4_org.json
@@ -1,13 +1,4 @@
 {
-	"grafana4_org state": {
-		"prefix": [
-			"grafana4_org."
-		],
-		"body": [
-			"grafana4_org.${1|absent,deep_diff,present|}:"
-		],
-		"description": "grafana4_org state"
-	},
 	"grafana4_org.absent": {
 		"prefix": "grafana4_org.absent:",
 		"body": [

--- a/snippets/grafana4_user.json
+++ b/snippets/grafana4_user.json
@@ -1,13 +1,4 @@
 {
-	"grafana4_user state": {
-		"prefix": [
-			"grafana4_user."
-		],
-		"body": [
-			"grafana4_user.${1|absent,deep_diff,present|}:"
-		],
-		"description": "grafana4_user state"
-	},
 	"grafana4_user.absent": {
 		"prefix": "grafana4_user.absent:",
 		"body": [

--- a/snippets/grafana4_user.json
+++ b/snippets/grafana4_user.json
@@ -1,0 +1,35 @@
+{
+	"grafana4_user state": {
+		"prefix": [
+			"grafana4_user."
+		],
+		"body": [
+			"grafana4_user.${1|absent,deep_diff,present|}:"
+		],
+		"description": "grafana4_user state"
+	},
+	"grafana4_user.absent": {
+		"prefix": "grafana4_user.absent:",
+		"body": [
+			"grafana4_user.absent:",
+			"$0"
+		],
+		"description": "grafana4_user.absent:"
+	},
+	"grafana4_user.deep_diff": {
+		"prefix": "grafana4_user.deep_diff:",
+		"body": [
+			"grafana4_user.deep_diff:",
+			"$0"
+		],
+		"description": "grafana4_user.deep_diff:"
+	},
+	"grafana4_user.present": {
+		"prefix": "grafana4_user.present:",
+		"body": [
+			"grafana4_user.present:",
+			"$0"
+		],
+		"description": "grafana4_user.present:"
+	}
+}

--- a/snippets/grains.json
+++ b/snippets/grains.json
@@ -1,13 +1,4 @@
 {
-	"grains state": {
-		"prefix": [
-			"grains."
-		],
-		"body": [
-			"grains.${1|absent,append,exists,list_absent,list_present,make_hashable,present|}:"
-		],
-		"description": "grains state"
-	},
 	"grains.absent": {
 		"prefix": "grains.absent:",
 		"body": [

--- a/snippets/grains.json
+++ b/snippets/grains.json
@@ -1,0 +1,67 @@
+{
+	"grains state": {
+		"prefix": [
+			"grains."
+		],
+		"body": [
+			"grains.${1|absent,append,exists,list_absent,list_present,make_hashable,present|}:"
+		],
+		"description": "grains state"
+	},
+	"grains.absent": {
+		"prefix": "grains.absent:",
+		"body": [
+			"grains.absent:",
+			"$0"
+		],
+		"description": "grains.absent:"
+	},
+	"grains.append": {
+		"prefix": "grains.append:",
+		"body": [
+			"grains.append:",
+			"$0"
+		],
+		"description": "grains.append:"
+	},
+	"grains.exists": {
+		"prefix": "grains.exists:",
+		"body": [
+			"grains.exists:",
+			"$0"
+		],
+		"description": "grains.exists:"
+	},
+	"grains.list_absent": {
+		"prefix": "grains.list_absent:",
+		"body": [
+			"grains.list_absent:",
+			"$0"
+		],
+		"description": "grains.list_absent:"
+	},
+	"grains.list_present": {
+		"prefix": "grains.list_present:",
+		"body": [
+			"grains.list_present:",
+			"$0"
+		],
+		"description": "grains.list_present:"
+	},
+	"grains.make_hashable": {
+		"prefix": "grains.make_hashable:",
+		"body": [
+			"grains.make_hashable:",
+			"$0"
+		],
+		"description": "grains.make_hashable:"
+	},
+	"grains.present": {
+		"prefix": "grains.present:",
+		"body": [
+			"grains.present:",
+			"$0"
+		],
+		"description": "grains.present:"
+	}
+}

--- a/snippets/group.json
+++ b/snippets/group.json
@@ -1,13 +1,4 @@
 {
-	"group state": {
-		"prefix": [
-			"group."
-		],
-		"body": [
-			"group.${1|absent,present|}:"
-		],
-		"description": "group state"
-	},
 	"group.absent": {
 		"prefix": "group.absent:",
 		"body": [

--- a/snippets/group.json
+++ b/snippets/group.json
@@ -1,0 +1,27 @@
+{
+	"group state": {
+		"prefix": [
+			"group."
+		],
+		"body": [
+			"group.${1|absent,present|}:"
+		],
+		"description": "group state"
+	},
+	"group.absent": {
+		"prefix": "group.absent:",
+		"body": [
+			"group.absent:",
+			"$0"
+		],
+		"description": "group.absent:"
+	},
+	"group.present": {
+		"prefix": "group.present:",
+		"body": [
+			"group.present:",
+			"$0"
+		],
+		"description": "group.present:"
+	}
+}

--- a/snippets/highstate_doc.json
+++ b/snippets/highstate_doc.json
@@ -1,13 +1,4 @@
 {
-	"highstate_doc state": {
-		"prefix": [
-			"highstate_doc."
-		],
-		"body": [
-			"highstate_doc.${1|note|}:"
-		],
-		"description": "highstate_doc state"
-	},
 	"highstate_doc.note": {
 		"prefix": "highstate_doc.note:",
 		"body": [

--- a/snippets/highstate_doc.json
+++ b/snippets/highstate_doc.json
@@ -1,0 +1,19 @@
+{
+	"highstate_doc state": {
+		"prefix": [
+			"highstate_doc."
+		],
+		"body": [
+			"highstate_doc.${1|note|}:"
+		],
+		"description": "highstate_doc state"
+	},
+	"highstate_doc.note": {
+		"prefix": "highstate_doc.note:",
+		"body": [
+			"highstate_doc.note:",
+			"$0"
+		],
+		"description": "highstate_doc.note:"
+	}
+}

--- a/snippets/host.json
+++ b/snippets/host.json
@@ -1,13 +1,4 @@
 {
-	"host state": {
-		"prefix": [
-			"host."
-		],
-		"body": [
-			"host.${1|absent,only,present|}:"
-		],
-		"description": "host state"
-	},
 	"host.absent": {
 		"prefix": "host.absent:",
 		"body": [

--- a/snippets/host.json
+++ b/snippets/host.json
@@ -1,0 +1,35 @@
+{
+	"host state": {
+		"prefix": [
+			"host."
+		],
+		"body": [
+			"host.${1|absent,only,present|}:"
+		],
+		"description": "host state"
+	},
+	"host.absent": {
+		"prefix": "host.absent:",
+		"body": [
+			"host.absent:",
+			"$0"
+		],
+		"description": "host.absent:"
+	},
+	"host.only": {
+		"prefix": "host.only:",
+		"body": [
+			"host.only:",
+			"$0"
+		],
+		"description": "host.only:"
+	},
+	"host.present": {
+		"prefix": "host.present:",
+		"body": [
+			"host.present:",
+			"$0"
+		],
+		"description": "host.present:"
+	}
+}

--- a/snippets/host.json
+++ b/snippets/host.json
@@ -3,6 +3,7 @@
 		"prefix": "host.absent:",
 		"body": [
 			"host.absent:",
+			"\t- name: ${1:host to remove}",
 			"$0"
 		],
 		"description": "host.absent:"
@@ -11,6 +12,7 @@
 		"prefix": "host.only:",
 		"body": [
 			"host.only:",
+			"\t- hostnames: ${1:hostnames}",
 			"$0"
 		],
 		"description": "host.only:"
@@ -19,6 +21,9 @@
 		"prefix": "host.present:",
 		"body": [
 			"host.present:",
+			"\t- name: ${1:host}",
+			"\t- ip: ${1:ip to apply}",
+			"\t- clean: False",
 			"$0"
 		],
 		"description": "host.present:"

--- a/snippets/http.json
+++ b/snippets/http.json
@@ -1,0 +1,27 @@
+{
+	"http state": {
+		"prefix": [
+			"http."
+		],
+		"body": [
+			"http.${1|query,wait_for_successful_query|}:"
+		],
+		"description": "http state"
+	},
+	"http.query": {
+		"prefix": "http.query:",
+		"body": [
+			"http.query:",
+			"$0"
+		],
+		"description": "http.query:"
+	},
+	"http.wait_for_successful_query": {
+		"prefix": "http.wait_for_successful_query:",
+		"body": [
+			"http.wait_for_successful_query:",
+			"$0"
+		],
+		"description": "http.wait_for_successful_query:"
+	}
+}

--- a/snippets/http.json
+++ b/snippets/http.json
@@ -3,6 +3,7 @@
 		"prefix": "http.query:",
 		"body": [
 			"http.query:",
+			"\t- name: ${1:site to query}",
 			"$0"
 		],
 		"description": "http.query:"
@@ -11,6 +12,7 @@
 		"prefix": "http.wait_for_successful_query:",
 		"body": [
 			"http.wait_for_successful_query:",
+			"\t- name: ${1:site to query}",
 			"$0"
 		],
 		"description": "http.wait_for_successful_query:"

--- a/snippets/http.json
+++ b/snippets/http.json
@@ -1,13 +1,4 @@
 {
-	"http state": {
-		"prefix": [
-			"http."
-		],
-		"body": [
-			"http.${1|query,wait_for_successful_query|}:"
-		],
-		"description": "http state"
-	},
 	"http.query": {
 		"prefix": "http.query:",
 		"body": [

--- a/snippets/incron.json
+++ b/snippets/incron.json
@@ -1,0 +1,27 @@
+{
+	"incron state": {
+		"prefix": [
+			"incron."
+		],
+		"body": [
+			"incron.${1|absent,present|}:"
+		],
+		"description": "incron state"
+	},
+	"incron.absent": {
+		"prefix": "incron.absent:",
+		"body": [
+			"incron.absent:",
+			"$0"
+		],
+		"description": "incron.absent:"
+	},
+	"incron.present": {
+		"prefix": "incron.present:",
+		"body": [
+			"incron.present:",
+			"$0"
+		],
+		"description": "incron.present:"
+	}
+}

--- a/snippets/incron.json
+++ b/snippets/incron.json
@@ -1,13 +1,4 @@
 {
-	"incron state": {
-		"prefix": [
-			"incron."
-		],
-		"body": [
-			"incron.${1|absent,present|}:"
-		],
-		"description": "incron state"
-	},
 	"incron.absent": {
 		"prefix": "incron.absent:",
 		"body": [

--- a/snippets/infoblox_a.json
+++ b/snippets/infoblox_a.json
@@ -1,13 +1,4 @@
 {
-	"infoblox_a state": {
-		"prefix": [
-			"infoblox_a."
-		],
-		"body": [
-			"infoblox_a.${1|absent,present|}:"
-		],
-		"description": "infoblox_a state"
-	},
 	"infoblox_a.absent": {
 		"prefix": "infoblox_a.absent:",
 		"body": [

--- a/snippets/infoblox_a.json
+++ b/snippets/infoblox_a.json
@@ -1,0 +1,27 @@
+{
+	"infoblox_a state": {
+		"prefix": [
+			"infoblox_a."
+		],
+		"body": [
+			"infoblox_a.${1|absent,present|}:"
+		],
+		"description": "infoblox_a state"
+	},
+	"infoblox_a.absent": {
+		"prefix": "infoblox_a.absent:",
+		"body": [
+			"infoblox_a.absent:",
+			"$0"
+		],
+		"description": "infoblox_a.absent:"
+	},
+	"infoblox_a.present": {
+		"prefix": "infoblox_a.present:",
+		"body": [
+			"infoblox_a.present:",
+			"$0"
+		],
+		"description": "infoblox_a.present:"
+	}
+}

--- a/snippets/infoblox_cname.json
+++ b/snippets/infoblox_cname.json
@@ -1,13 +1,4 @@
 {
-	"infoblox_cname state": {
-		"prefix": [
-			"infoblox_cname."
-		],
-		"body": [
-			"infoblox_cname.${1|absent,present|}:"
-		],
-		"description": "infoblox_cname state"
-	},
 	"infoblox_cname.absent": {
 		"prefix": "infoblox_cname.absent:",
 		"body": [

--- a/snippets/infoblox_cname.json
+++ b/snippets/infoblox_cname.json
@@ -1,0 +1,27 @@
+{
+	"infoblox_cname state": {
+		"prefix": [
+			"infoblox_cname."
+		],
+		"body": [
+			"infoblox_cname.${1|absent,present|}:"
+		],
+		"description": "infoblox_cname state"
+	},
+	"infoblox_cname.absent": {
+		"prefix": "infoblox_cname.absent:",
+		"body": [
+			"infoblox_cname.absent:",
+			"$0"
+		],
+		"description": "infoblox_cname.absent:"
+	},
+	"infoblox_cname.present": {
+		"prefix": "infoblox_cname.present:",
+		"body": [
+			"infoblox_cname.present:",
+			"$0"
+		],
+		"description": "infoblox_cname.present:"
+	}
+}

--- a/snippets/infoblox_host_record.json
+++ b/snippets/infoblox_host_record.json
@@ -1,13 +1,4 @@
 {
-	"infoblox_host_record state": {
-		"prefix": [
-			"infoblox_host_record."
-		],
-		"body": [
-			"infoblox_host_record.${1|absent,present|}:"
-		],
-		"description": "infoblox_host_record state"
-	},
 	"infoblox_host_record.absent": {
 		"prefix": "infoblox_host_record.absent:",
 		"body": [

--- a/snippets/infoblox_host_record.json
+++ b/snippets/infoblox_host_record.json
@@ -1,0 +1,27 @@
+{
+	"infoblox_host_record state": {
+		"prefix": [
+			"infoblox_host_record."
+		],
+		"body": [
+			"infoblox_host_record.${1|absent,present|}:"
+		],
+		"description": "infoblox_host_record state"
+	},
+	"infoblox_host_record.absent": {
+		"prefix": "infoblox_host_record.absent:",
+		"body": [
+			"infoblox_host_record.absent:",
+			"$0"
+		],
+		"description": "infoblox_host_record.absent:"
+	},
+	"infoblox_host_record.present": {
+		"prefix": "infoblox_host_record.present:",
+		"body": [
+			"infoblox_host_record.present:",
+			"$0"
+		],
+		"description": "infoblox_host_record.present:"
+	}
+}

--- a/snippets/infoblox_range.json
+++ b/snippets/infoblox_range.json
@@ -1,0 +1,27 @@
+{
+	"infoblox_range state": {
+		"prefix": [
+			"infoblox_range."
+		],
+		"body": [
+			"infoblox_range.${1|absent,present|}:"
+		],
+		"description": "infoblox_range state"
+	},
+	"infoblox_range.absent": {
+		"prefix": "infoblox_range.absent:",
+		"body": [
+			"infoblox_range.absent:",
+			"$0"
+		],
+		"description": "infoblox_range.absent:"
+	},
+	"infoblox_range.present": {
+		"prefix": "infoblox_range.present:",
+		"body": [
+			"infoblox_range.present:",
+			"$0"
+		],
+		"description": "infoblox_range.present:"
+	}
+}

--- a/snippets/infoblox_range.json
+++ b/snippets/infoblox_range.json
@@ -1,13 +1,4 @@
 {
-	"infoblox_range state": {
-		"prefix": [
-			"infoblox_range."
-		],
-		"body": [
-			"infoblox_range.${1|absent,present|}:"
-		],
-		"description": "infoblox_range state"
-	},
 	"infoblox_range.absent": {
 		"prefix": "infoblox_range.absent:",
 		"body": [

--- a/snippets/ini.json
+++ b/snippets/ini.json
@@ -1,0 +1,43 @@
+{
+	"ini state": {
+		"prefix": [
+			"ini."
+		],
+		"body": [
+			"ini.${1|options_absent,options_present,sections_absent,sections_present|}:"
+		],
+		"description": "ini state"
+	},
+	"ini.options_absent": {
+		"prefix": "ini.options_absent:",
+		"body": [
+			"ini.options_absent:",
+			"$0"
+		],
+		"description": "ini.options_absent:"
+	},
+	"ini.options_present": {
+		"prefix": "ini.options_present:",
+		"body": [
+			"ini.options_present:",
+			"$0"
+		],
+		"description": "ini.options_present:"
+	},
+	"ini.sections_absent": {
+		"prefix": "ini.sections_absent:",
+		"body": [
+			"ini.sections_absent:",
+			"$0"
+		],
+		"description": "ini.sections_absent:"
+	},
+	"ini.sections_present": {
+		"prefix": "ini.sections_present:",
+		"body": [
+			"ini.sections_present:",
+			"$0"
+		],
+		"description": "ini.sections_present:"
+	}
+}

--- a/snippets/ini.json
+++ b/snippets/ini.json
@@ -1,13 +1,4 @@
 {
-	"ini state": {
-		"prefix": [
-			"ini."
-		],
-		"body": [
-			"ini.${1|options_absent,options_present,sections_absent,sections_present|}:"
-		],
-		"description": "ini state"
-	},
 	"ini.options_absent": {
 		"prefix": "ini.options_absent:",
 		"body": [

--- a/snippets/iptables.json
+++ b/snippets/iptables.json
@@ -1,0 +1,75 @@
+{
+	"iptables state": {
+		"prefix": [
+			"iptables."
+		],
+		"body": [
+			"iptables.${1|append,chain_absent,chain_present,delete,flush,insert,mod_aggregate,set_policy|}:"
+		],
+		"description": "iptables state"
+	},
+	"iptables.append": {
+		"prefix": "iptables.append:",
+		"body": [
+			"iptables.append:",
+			"$0"
+		],
+		"description": "iptables.append:"
+	},
+	"iptables.chain_absent": {
+		"prefix": "iptables.chain_absent:",
+		"body": [
+			"iptables.chain_absent:",
+			"$0"
+		],
+		"description": "iptables.chain_absent:"
+	},
+	"iptables.chain_present": {
+		"prefix": "iptables.chain_present:",
+		"body": [
+			"iptables.chain_present:",
+			"$0"
+		],
+		"description": "iptables.chain_present:"
+	},
+	"iptables.delete": {
+		"prefix": "iptables.delete:",
+		"body": [
+			"iptables.delete:",
+			"$0"
+		],
+		"description": "iptables.delete:"
+	},
+	"iptables.flush": {
+		"prefix": "iptables.flush:",
+		"body": [
+			"iptables.flush:",
+			"$0"
+		],
+		"description": "iptables.flush:"
+	},
+	"iptables.insert": {
+		"prefix": "iptables.insert:",
+		"body": [
+			"iptables.insert:",
+			"$0"
+		],
+		"description": "iptables.insert:"
+	},
+	"iptables.mod_aggregate": {
+		"prefix": "iptables.mod_aggregate:",
+		"body": [
+			"iptables.mod_aggregate:",
+			"$0"
+		],
+		"description": "iptables.mod_aggregate:"
+	},
+	"iptables.set_policy": {
+		"prefix": "iptables.set_policy:",
+		"body": [
+			"iptables.set_policy:",
+			"$0"
+		],
+		"description": "iptables.set_policy:"
+	}
+}

--- a/snippets/iptables.json
+++ b/snippets/iptables.json
@@ -1,13 +1,4 @@
 {
-	"iptables state": {
-		"prefix": [
-			"iptables."
-		],
-		"body": [
-			"iptables.${1|append,chain_absent,chain_present,delete,flush,insert,mod_aggregate,set_policy|}:"
-		],
-		"description": "iptables state"
-	},
 	"iptables.append": {
 		"prefix": "iptables.append:",
 		"body": [

--- a/snippets/jboss7.json
+++ b/snippets/jboss7.json
@@ -1,0 +1,43 @@
+{
+	"jboss7 state": {
+		"prefix": [
+			"jboss7."
+		],
+		"body": [
+			"jboss7.${1|bindings_exist,datasource_exists,deployed,reloaded|}:"
+		],
+		"description": "jboss7 state"
+	},
+	"jboss7.bindings_exist": {
+		"prefix": "jboss7.bindings_exist:",
+		"body": [
+			"jboss7.bindings_exist:",
+			"$0"
+		],
+		"description": "jboss7.bindings_exist:"
+	},
+	"jboss7.datasource_exists": {
+		"prefix": "jboss7.datasource_exists:",
+		"body": [
+			"jboss7.datasource_exists:",
+			"$0"
+		],
+		"description": "jboss7.datasource_exists:"
+	},
+	"jboss7.deployed": {
+		"prefix": "jboss7.deployed:",
+		"body": [
+			"jboss7.deployed:",
+			"$0"
+		],
+		"description": "jboss7.deployed:"
+	},
+	"jboss7.reloaded": {
+		"prefix": "jboss7.reloaded:",
+		"body": [
+			"jboss7.reloaded:",
+			"$0"
+		],
+		"description": "jboss7.reloaded:"
+	}
+}

--- a/snippets/jboss7.json
+++ b/snippets/jboss7.json
@@ -1,13 +1,4 @@
 {
-	"jboss7 state": {
-		"prefix": [
-			"jboss7."
-		],
-		"body": [
-			"jboss7.${1|bindings_exist,datasource_exists,deployed,reloaded|}:"
-		],
-		"description": "jboss7 state"
-	},
 	"jboss7.bindings_exist": {
 		"prefix": "jboss7.bindings_exist:",
 		"body": [

--- a/snippets/jenkins.json
+++ b/snippets/jenkins.json
@@ -1,13 +1,4 @@
 {
-	"jenkins state": {
-		"prefix": [
-			"jenkins."
-		],
-		"body": [
-			"jenkins.${1|absent,present|}:"
-		],
-		"description": "jenkins state"
-	},
 	"jenkins.absent": {
 		"prefix": "jenkins.absent:",
 		"body": [

--- a/snippets/jenkins.json
+++ b/snippets/jenkins.json
@@ -1,0 +1,27 @@
+{
+	"jenkins state": {
+		"prefix": [
+			"jenkins."
+		],
+		"body": [
+			"jenkins.${1|absent,present|}:"
+		],
+		"description": "jenkins state"
+	},
+	"jenkins.absent": {
+		"prefix": "jenkins.absent:",
+		"body": [
+			"jenkins.absent:",
+			"$0"
+		],
+		"description": "jenkins.absent:"
+	},
+	"jenkins.present": {
+		"prefix": "jenkins.present:",
+		"body": [
+			"jenkins.present:",
+			"$0"
+		],
+		"description": "jenkins.present:"
+	}
+}

--- a/snippets/junos.json
+++ b/snippets/junos.json
@@ -1,13 +1,4 @@
 {
-	"junos state": {
-		"prefix": [
-			"junos."
-		],
-		"body": [
-			"junos.${1|cli,commit,commit_check,diff,file_copy,install_config,install_os,load,lock,resultdecorator,rollback,rpc,set_hostname,shutdown,unlock,wraps,zeroize|}:"
-		],
-		"description": "junos state"
-	},
 	"junos.cli": {
 		"prefix": "junos.cli:",
 		"body": [

--- a/snippets/junos.json
+++ b/snippets/junos.json
@@ -1,0 +1,147 @@
+{
+	"junos state": {
+		"prefix": [
+			"junos."
+		],
+		"body": [
+			"junos.${1|cli,commit,commit_check,diff,file_copy,install_config,install_os,load,lock,resultdecorator,rollback,rpc,set_hostname,shutdown,unlock,wraps,zeroize|}:"
+		],
+		"description": "junos state"
+	},
+	"junos.cli": {
+		"prefix": "junos.cli:",
+		"body": [
+			"junos.cli:",
+			"$0"
+		],
+		"description": "junos.cli:"
+	},
+	"junos.commit": {
+		"prefix": "junos.commit:",
+		"body": [
+			"junos.commit:",
+			"$0"
+		],
+		"description": "junos.commit:"
+	},
+	"junos.commit_check": {
+		"prefix": "junos.commit_check:",
+		"body": [
+			"junos.commit_check:",
+			"$0"
+		],
+		"description": "junos.commit_check:"
+	},
+	"junos.diff": {
+		"prefix": "junos.diff:",
+		"body": [
+			"junos.diff:",
+			"$0"
+		],
+		"description": "junos.diff:"
+	},
+	"junos.file_copy": {
+		"prefix": "junos.file_copy:",
+		"body": [
+			"junos.file_copy:",
+			"$0"
+		],
+		"description": "junos.file_copy:"
+	},
+	"junos.install_config": {
+		"prefix": "junos.install_config:",
+		"body": [
+			"junos.install_config:",
+			"$0"
+		],
+		"description": "junos.install_config:"
+	},
+	"junos.install_os": {
+		"prefix": "junos.install_os:",
+		"body": [
+			"junos.install_os:",
+			"$0"
+		],
+		"description": "junos.install_os:"
+	},
+	"junos.load": {
+		"prefix": "junos.load:",
+		"body": [
+			"junos.load:",
+			"$0"
+		],
+		"description": "junos.load:"
+	},
+	"junos.lock": {
+		"prefix": "junos.lock:",
+		"body": [
+			"junos.lock:",
+			"$0"
+		],
+		"description": "junos.lock:"
+	},
+	"junos.resultdecorator": {
+		"prefix": "junos.resultdecorator:",
+		"body": [
+			"junos.resultdecorator:",
+			"$0"
+		],
+		"description": "junos.resultdecorator:"
+	},
+	"junos.rollback": {
+		"prefix": "junos.rollback:",
+		"body": [
+			"junos.rollback:",
+			"$0"
+		],
+		"description": "junos.rollback:"
+	},
+	"junos.rpc": {
+		"prefix": "junos.rpc:",
+		"body": [
+			"junos.rpc:",
+			"$0"
+		],
+		"description": "junos.rpc:"
+	},
+	"junos.set_hostname": {
+		"prefix": "junos.set_hostname:",
+		"body": [
+			"junos.set_hostname:",
+			"$0"
+		],
+		"description": "junos.set_hostname:"
+	},
+	"junos.shutdown": {
+		"prefix": "junos.shutdown:",
+		"body": [
+			"junos.shutdown:",
+			"$0"
+		],
+		"description": "junos.shutdown:"
+	},
+	"junos.unlock": {
+		"prefix": "junos.unlock:",
+		"body": [
+			"junos.unlock:",
+			"$0"
+		],
+		"description": "junos.unlock:"
+	},
+	"junos.wraps": {
+		"prefix": "junos.wraps:",
+		"body": [
+			"junos.wraps:",
+			"$0"
+		],
+		"description": "junos.wraps:"
+	},
+	"junos.zeroize": {
+		"prefix": "junos.zeroize:",
+		"body": [
+			"junos.zeroize:",
+			"$0"
+		],
+		"description": "junos.zeroize:"
+	}
+}

--- a/snippets/keyboard.json
+++ b/snippets/keyboard.json
@@ -1,13 +1,4 @@
 {
-	"keyboard state": {
-		"prefix": [
-			"keyboard."
-		],
-		"body": [
-			"keyboard.${1|system,xorg|}:"
-		],
-		"description": "keyboard state"
-	},
 	"keyboard.system": {
 		"prefix": "keyboard.system:",
 		"body": [

--- a/snippets/keyboard.json
+++ b/snippets/keyboard.json
@@ -1,0 +1,27 @@
+{
+	"keyboard state": {
+		"prefix": [
+			"keyboard."
+		],
+		"body": [
+			"keyboard.${1|system,xorg|}:"
+		],
+		"description": "keyboard state"
+	},
+	"keyboard.system": {
+		"prefix": "keyboard.system:",
+		"body": [
+			"keyboard.system:",
+			"$0"
+		],
+		"description": "keyboard.system:"
+	},
+	"keyboard.xorg": {
+		"prefix": "keyboard.xorg:",
+		"body": [
+			"keyboard.xorg:",
+			"$0"
+		],
+		"description": "keyboard.xorg:"
+	}
+}

--- a/snippets/keystore.json
+++ b/snippets/keystore.json
@@ -1,0 +1,14 @@
+{
+	"keystore.managed": {
+		"prefix": "keystore.managed:",
+		"body": [
+            "keystore.managed:",
+            "  - name: ${1:path to keystore file}",
+            "  - passphrase: ${2:password to keystore}",
+            "  - entries:",
+            "    - alias: ${3:alias}",
+            "    - certificate: ${4:certificate}",
+			"$0"
+		],
+		"description": "keystore.managed:"
+	}

--- a/snippets/ldap.json
+++ b/snippets/ldap.json
@@ -1,0 +1,19 @@
+{
+	"ldap state": {
+		"prefix": [
+			"ldap."
+		],
+		"body": [
+			"ldap.${1|managed|}:"
+		],
+		"description": "ldap state"
+	},
+	"ldap.managed": {
+		"prefix": "ldap.managed:",
+		"body": [
+			"ldap.managed:",
+			"$0"
+		],
+		"description": "ldap.managed:"
+	}
+}

--- a/snippets/ldap.json
+++ b/snippets/ldap.json
@@ -1,13 +1,4 @@
 {
-	"ldap state": {
-		"prefix": [
-			"ldap."
-		],
-		"body": [
-			"ldap.${1|managed|}:"
-		],
-		"description": "ldap state"
-	},
 	"ldap.managed": {
 		"prefix": "ldap.managed:",
 		"body": [

--- a/snippets/lgpo.json
+++ b/snippets/lgpo.json
@@ -1,0 +1,10 @@
+{
+	"lgpo.set": {
+		"body": [
+			"lgpo.set:",
+			"$0"
+		],
+		"prefix": "lgpo.set:",
+		"description": "lgpo.set:"
+	}
+}

--- a/snippets/libcloud_dns.json
+++ b/snippets/libcloud_dns.json
@@ -1,13 +1,4 @@
 {
-	"libcloud_dns state": {
-		"prefix": [
-			"libcloud_dns."
-		],
-		"body": [
-			"libcloud_dns.${1|record_absent,record_present,state_result,zone_absent,zone_present|}:"
-		],
-		"description": "libcloud_dns state"
-	},
 	"libcloud_dns.record_absent": {
 		"prefix": "libcloud_dns.record_absent:",
 		"body": [

--- a/snippets/libcloud_dns.json
+++ b/snippets/libcloud_dns.json
@@ -1,0 +1,51 @@
+{
+	"libcloud_dns state": {
+		"prefix": [
+			"libcloud_dns."
+		],
+		"body": [
+			"libcloud_dns.${1|record_absent,record_present,state_result,zone_absent,zone_present|}:"
+		],
+		"description": "libcloud_dns state"
+	},
+	"libcloud_dns.record_absent": {
+		"prefix": "libcloud_dns.record_absent:",
+		"body": [
+			"libcloud_dns.record_absent:",
+			"$0"
+		],
+		"description": "libcloud_dns.record_absent:"
+	},
+	"libcloud_dns.record_present": {
+		"prefix": "libcloud_dns.record_present:",
+		"body": [
+			"libcloud_dns.record_present:",
+			"$0"
+		],
+		"description": "libcloud_dns.record_present:"
+	},
+	"libcloud_dns.state_result": {
+		"prefix": "libcloud_dns.state_result:",
+		"body": [
+			"libcloud_dns.state_result:",
+			"$0"
+		],
+		"description": "libcloud_dns.state_result:"
+	},
+	"libcloud_dns.zone_absent": {
+		"prefix": "libcloud_dns.zone_absent:",
+		"body": [
+			"libcloud_dns.zone_absent:",
+			"$0"
+		],
+		"description": "libcloud_dns.zone_absent:"
+	},
+	"libcloud_dns.zone_present": {
+		"prefix": "libcloud_dns.zone_present:",
+		"body": [
+			"libcloud_dns.zone_present:",
+			"$0"
+		],
+		"description": "libcloud_dns.zone_present:"
+	}
+}

--- a/snippets/libcloud_loadbalancer.json
+++ b/snippets/libcloud_loadbalancer.json
@@ -1,0 +1,51 @@
+{
+	"libcloud_loadbalancer state": {
+		"prefix": [
+			"libcloud_loadbalancer."
+		],
+		"body": [
+			"libcloud_loadbalancer.${1|balancer_absent,balancer_present,member_absent,member_present,state_result|}:"
+		],
+		"description": "libcloud_loadbalancer state"
+	},
+	"libcloud_loadbalancer.balancer_absent": {
+		"prefix": "libcloud_loadbalancer.balancer_absent:",
+		"body": [
+			"libcloud_loadbalancer.balancer_absent:",
+			"$0"
+		],
+		"description": "libcloud_loadbalancer.balancer_absent:"
+	},
+	"libcloud_loadbalancer.balancer_present": {
+		"prefix": "libcloud_loadbalancer.balancer_present:",
+		"body": [
+			"libcloud_loadbalancer.balancer_present:",
+			"$0"
+		],
+		"description": "libcloud_loadbalancer.balancer_present:"
+	},
+	"libcloud_loadbalancer.member_absent": {
+		"prefix": "libcloud_loadbalancer.member_absent:",
+		"body": [
+			"libcloud_loadbalancer.member_absent:",
+			"$0"
+		],
+		"description": "libcloud_loadbalancer.member_absent:"
+	},
+	"libcloud_loadbalancer.member_present": {
+		"prefix": "libcloud_loadbalancer.member_present:",
+		"body": [
+			"libcloud_loadbalancer.member_present:",
+			"$0"
+		],
+		"description": "libcloud_loadbalancer.member_present:"
+	},
+	"libcloud_loadbalancer.state_result": {
+		"prefix": "libcloud_loadbalancer.state_result:",
+		"body": [
+			"libcloud_loadbalancer.state_result:",
+			"$0"
+		],
+		"description": "libcloud_loadbalancer.state_result:"
+	}
+}

--- a/snippets/libcloud_loadbalancer.json
+++ b/snippets/libcloud_loadbalancer.json
@@ -1,13 +1,4 @@
 {
-	"libcloud_loadbalancer state": {
-		"prefix": [
-			"libcloud_loadbalancer."
-		],
-		"body": [
-			"libcloud_loadbalancer.${1|balancer_absent,balancer_present,member_absent,member_present,state_result|}:"
-		],
-		"description": "libcloud_loadbalancer state"
-	},
 	"libcloud_loadbalancer.balancer_absent": {
 		"prefix": "libcloud_loadbalancer.balancer_absent:",
 		"body": [

--- a/snippets/libcloud_storage.json
+++ b/snippets/libcloud_storage.json
@@ -1,13 +1,4 @@
 {
-	"libcloud_storage state": {
-		"prefix": [
-			"libcloud_storage."
-		],
-		"body": [
-			"libcloud_storage.${1|container_absent,container_present,file_present,object_absent,object_present,state_result|}:"
-		],
-		"description": "libcloud_storage state"
-	},
 	"libcloud_storage.container_absent": {
 		"prefix": "libcloud_storage.container_absent:",
 		"body": [

--- a/snippets/libcloud_storage.json
+++ b/snippets/libcloud_storage.json
@@ -1,0 +1,59 @@
+{
+	"libcloud_storage state": {
+		"prefix": [
+			"libcloud_storage."
+		],
+		"body": [
+			"libcloud_storage.${1|container_absent,container_present,file_present,object_absent,object_present,state_result|}:"
+		],
+		"description": "libcloud_storage state"
+	},
+	"libcloud_storage.container_absent": {
+		"prefix": "libcloud_storage.container_absent:",
+		"body": [
+			"libcloud_storage.container_absent:",
+			"$0"
+		],
+		"description": "libcloud_storage.container_absent:"
+	},
+	"libcloud_storage.container_present": {
+		"prefix": "libcloud_storage.container_present:",
+		"body": [
+			"libcloud_storage.container_present:",
+			"$0"
+		],
+		"description": "libcloud_storage.container_present:"
+	},
+	"libcloud_storage.file_present": {
+		"prefix": "libcloud_storage.file_present:",
+		"body": [
+			"libcloud_storage.file_present:",
+			"$0"
+		],
+		"description": "libcloud_storage.file_present:"
+	},
+	"libcloud_storage.object_absent": {
+		"prefix": "libcloud_storage.object_absent:",
+		"body": [
+			"libcloud_storage.object_absent:",
+			"$0"
+		],
+		"description": "libcloud_storage.object_absent:"
+	},
+	"libcloud_storage.object_present": {
+		"prefix": "libcloud_storage.object_present:",
+		"body": [
+			"libcloud_storage.object_present:",
+			"$0"
+		],
+		"description": "libcloud_storage.object_present:"
+	},
+	"libcloud_storage.state_result": {
+		"prefix": "libcloud_storage.state_result:",
+		"body": [
+			"libcloud_storage.state_result:",
+			"$0"
+		],
+		"description": "libcloud_storage.state_result:"
+	}
+}

--- a/snippets/license.json
+++ b/snippets/license.json
@@ -1,0 +1,10 @@
+{
+	"license.activate": {
+		"body": [
+			"license.activate:",
+			"$0"
+		],
+		"prefix": "license.activate:",
+		"description": "license.activate:"
+	}
+}

--- a/snippets/locale.json
+++ b/snippets/locale.json
@@ -1,13 +1,4 @@
 {
-	"locale state": {
-		"prefix": [
-			"locale."
-		],
-		"body": [
-			"locale.${1|present,system|}:"
-		],
-		"description": "locale state"
-	},
 	"locale.present": {
 		"prefix": "locale.present:",
 		"body": [

--- a/snippets/locale.json
+++ b/snippets/locale.json
@@ -1,0 +1,27 @@
+{
+	"locale state": {
+		"prefix": [
+			"locale."
+		],
+		"body": [
+			"locale.${1|present,system|}:"
+		],
+		"description": "locale state"
+	},
+	"locale.present": {
+		"prefix": "locale.present:",
+		"body": [
+			"locale.present:",
+			"$0"
+		],
+		"description": "locale.present:"
+	},
+	"locale.system": {
+		"prefix": "locale.system:",
+		"body": [
+			"locale.system:",
+			"$0"
+		],
+		"description": "locale.system:"
+	}
+}

--- a/snippets/logrotate.json
+++ b/snippets/logrotate.json
@@ -1,0 +1,19 @@
+{
+	"logrotate state": {
+		"prefix": [
+			"logrotate."
+		],
+		"body": [
+			"logrotate.${1|set|}:"
+		],
+		"description": "logrotate state"
+	},
+	"logrotate.set": {
+		"prefix": "logrotate.set:",
+		"body": [
+			"logrotate.set:",
+			"$0"
+		],
+		"description": "logrotate.set:"
+	}
+}

--- a/snippets/logrotate.json
+++ b/snippets/logrotate.json
@@ -1,13 +1,4 @@
 {
-	"logrotate state": {
-		"prefix": [
-			"logrotate."
-		],
-		"body": [
-			"logrotate.${1|set|}:"
-		],
-		"description": "logrotate state"
-	},
 	"logrotate.set": {
 		"prefix": "logrotate.set:",
 		"body": [

--- a/snippets/loop.json
+++ b/snippets/loop.json
@@ -1,0 +1,27 @@
+{
+	"loop state": {
+		"prefix": [
+			"loop."
+		],
+		"body": [
+			"loop.${1|until,until_no_eval|}:"
+		],
+		"description": "loop state"
+	},
+	"loop.until": {
+		"prefix": "loop.until:",
+		"body": [
+			"loop.until:",
+			"$0"
+		],
+		"description": "loop.until:"
+	},
+	"loop.until_no_eval": {
+		"prefix": "loop.until_no_eval:",
+		"body": [
+			"loop.until_no_eval:",
+			"$0"
+		],
+		"description": "loop.until_no_eval:"
+	}
+}

--- a/snippets/loop.json
+++ b/snippets/loop.json
@@ -1,13 +1,4 @@
 {
-	"loop state": {
-		"prefix": [
-			"loop."
-		],
-		"body": [
-			"loop.${1|until,until_no_eval|}:"
-		],
-		"description": "loop state"
-	},
 	"loop.until": {
 		"prefix": "loop.until:",
 		"body": [

--- a/snippets/lxc.json
+++ b/snippets/lxc.json
@@ -1,0 +1,67 @@
+{
+	"lxc state": {
+		"prefix": [
+			"lxc."
+		],
+		"body": [
+			"lxc.${1|absent,edited_conf,frozen,present,running,set_pass,stopped|}:"
+		],
+		"description": "lxc state"
+	},
+	"lxc.absent": {
+		"prefix": "lxc.absent:",
+		"body": [
+			"lxc.absent:",
+			"$0"
+		],
+		"description": "lxc.absent:"
+	},
+	"lxc.edited_conf": {
+		"prefix": "lxc.edited_conf:",
+		"body": [
+			"lxc.edited_conf:",
+			"$0"
+		],
+		"description": "lxc.edited_conf:"
+	},
+	"lxc.frozen": {
+		"prefix": "lxc.frozen:",
+		"body": [
+			"lxc.frozen:",
+			"$0"
+		],
+		"description": "lxc.frozen:"
+	},
+	"lxc.present": {
+		"prefix": "lxc.present:",
+		"body": [
+			"lxc.present:",
+			"$0"
+		],
+		"description": "lxc.present:"
+	},
+	"lxc.running": {
+		"prefix": "lxc.running:",
+		"body": [
+			"lxc.running:",
+			"$0"
+		],
+		"description": "lxc.running:"
+	},
+	"lxc.set_pass": {
+		"prefix": "lxc.set_pass:",
+		"body": [
+			"lxc.set_pass:",
+			"$0"
+		],
+		"description": "lxc.set_pass:"
+	},
+	"lxc.stopped": {
+		"prefix": "lxc.stopped:",
+		"body": [
+			"lxc.stopped:",
+			"$0"
+		],
+		"description": "lxc.stopped:"
+	}
+}

--- a/snippets/lxc.json
+++ b/snippets/lxc.json
@@ -1,13 +1,4 @@
 {
-	"lxc state": {
-		"prefix": [
-			"lxc."
-		],
-		"body": [
-			"lxc.${1|absent,edited_conf,frozen,present,running,set_pass,stopped|}:"
-		],
-		"description": "lxc state"
-	},
 	"lxc.absent": {
 		"prefix": "lxc.absent:",
 		"body": [

--- a/snippets/marathon_app.json
+++ b/snippets/marathon_app.json
@@ -1,13 +1,4 @@
 {
-	"marathon_app state": {
-		"prefix": [
-			"marathon_app."
-		],
-		"body": [
-			"marathon_app.${1|absent,config,running|}:"
-		],
-		"description": "marathon_app state"
-	},
 	"marathon_app.absent": {
 		"prefix": "marathon_app.absent:",
 		"body": [

--- a/snippets/marathon_app.json
+++ b/snippets/marathon_app.json
@@ -1,0 +1,35 @@
+{
+	"marathon_app state": {
+		"prefix": [
+			"marathon_app."
+		],
+		"body": [
+			"marathon_app.${1|absent,config,running|}:"
+		],
+		"description": "marathon_app state"
+	},
+	"marathon_app.absent": {
+		"prefix": "marathon_app.absent:",
+		"body": [
+			"marathon_app.absent:",
+			"$0"
+		],
+		"description": "marathon_app.absent:"
+	},
+	"marathon_app.config": {
+		"prefix": "marathon_app.config:",
+		"body": [
+			"marathon_app.config:",
+			"$0"
+		],
+		"description": "marathon_app.config:"
+	},
+	"marathon_app.running": {
+		"prefix": "marathon_app.running:",
+		"body": [
+			"marathon_app.running:",
+			"$0"
+		],
+		"description": "marathon_app.running:"
+	}
+}

--- a/snippets/moby_container.json
+++ b/snippets/moby_container.json
@@ -1,0 +1,42 @@
+{
+	"moby_container.absent": {
+		"prefix": "moby_container.absent:",
+		"body": [
+			"moby_container.absent:",
+			"$0"
+		],
+		"description": "moby_container.absent:"
+	},
+	"moby_container.mod_run_check": {
+		"prefix": "moby_container.mod_run_check:",
+		"body": [
+			"moby_container.mod_run_check:",
+			"$0"
+		],
+		"description": "moby_container.mod_run_check:"
+	},
+	"moby_container.run": {
+		"prefix": "moby_container.run:",
+		"body": [
+			"moby_container.run:",
+			"$0"
+		],
+		"description": "moby_container.run:"
+	},
+	"moby_container.running": {
+		"prefix": "moby_container.running:",
+		"body": [
+			"moby_container.running:",
+			"$0"
+		],
+		"description": "moby_container.running:"
+	},
+	"moby_container.stopped": {
+		"prefix": "moby_container.stopped:",
+		"body": [
+			"moby_container.stopped:",
+			"$0"
+		],
+		"description": "moby_container.stopped:"
+	}
+}

--- a/snippets/moby_image.json
+++ b/snippets/moby_image.json
@@ -1,0 +1,18 @@
+{
+	"moby_image.absent": {
+		"prefix": "moby_image.absent:",
+		"body": [
+			"moby_image.absent:",
+			"$0"
+		],
+		"description": "moby_image.absent:"
+	},
+	"moby_image.present": {
+		"prefix": "moby_image.present:",
+		"body": [
+			"moby_image.present:",
+			"$0"
+		],
+		"description": "moby_image.present:"
+	}
+}

--- a/snippets/moby_network.json
+++ b/snippets/moby_network.json
@@ -1,0 +1,18 @@
+{
+	"moby_network.absent": {
+		"prefix": "moby_network.absent:",
+		"body": [
+			"moby_network.absent:",
+			"$0"
+		],
+		"description": "moby_network.absent:"
+	},
+	"moby_network.present": {
+		"prefix": "moby_network.present:",
+		"body": [
+			"moby_network.present:",
+			"$0"
+		],
+		"description": "moby_network.present:"
+	}
+}

--- a/snippets/moby_volume.json
+++ b/snippets/moby_volume.json
@@ -1,0 +1,18 @@
+{
+	"moby_volume.absent": {
+		"prefix": "moby_volume.absent:",
+		"body": [
+			"moby_volume.absent:",
+			"$0"
+		],
+		"description": "moby_volume.absent:"
+	},
+	"moby_volume.present": {
+		"prefix": "moby_volume.present:",
+		"body": [
+			"moby_volume.present:",
+			"$0"
+		],
+		"description": "moby_volume.present:"
+	}
+}

--- a/snippets/modjk.json
+++ b/snippets/modjk.json
@@ -1,0 +1,43 @@
+{
+	"modjk state": {
+		"prefix": [
+			"modjk."
+		],
+		"body": [
+			"modjk.${1|worker_activated,worker_disabled,worker_recover,worker_stopped|}:"
+		],
+		"description": "modjk state"
+	},
+	"modjk.worker_activated": {
+		"prefix": "modjk.worker_activated:",
+		"body": [
+			"modjk.worker_activated:",
+			"$0"
+		],
+		"description": "modjk.worker_activated:"
+	},
+	"modjk.worker_disabled": {
+		"prefix": "modjk.worker_disabled:",
+		"body": [
+			"modjk.worker_disabled:",
+			"$0"
+		],
+		"description": "modjk.worker_disabled:"
+	},
+	"modjk.worker_recover": {
+		"prefix": "modjk.worker_recover:",
+		"body": [
+			"modjk.worker_recover:",
+			"$0"
+		],
+		"description": "modjk.worker_recover:"
+	},
+	"modjk.worker_stopped": {
+		"prefix": "modjk.worker_stopped:",
+		"body": [
+			"modjk.worker_stopped:",
+			"$0"
+		],
+		"description": "modjk.worker_stopped:"
+	}
+}

--- a/snippets/modjk.json
+++ b/snippets/modjk.json
@@ -1,13 +1,4 @@
 {
-	"modjk state": {
-		"prefix": [
-			"modjk."
-		],
-		"body": [
-			"modjk.${1|worker_activated,worker_disabled,worker_recover,worker_stopped|}:"
-		],
-		"description": "modjk state"
-	},
 	"modjk.worker_activated": {
 		"prefix": "modjk.worker_activated:",
 		"body": [

--- a/snippets/modjk_worker.json
+++ b/snippets/modjk_worker.json
@@ -1,0 +1,35 @@
+{
+	"modjk_worker state": {
+		"prefix": [
+			"modjk_worker."
+		],
+		"body": [
+			"modjk_worker.${1|activate,disable,stop|}:"
+		],
+		"description": "modjk_worker state"
+	},
+	"modjk_worker.activate": {
+		"prefix": "modjk_worker.activate:",
+		"body": [
+			"modjk_worker.activate:",
+			"$0"
+		],
+		"description": "modjk_worker.activate:"
+	},
+	"modjk_worker.disable": {
+		"prefix": "modjk_worker.disable:",
+		"body": [
+			"modjk_worker.disable:",
+			"$0"
+		],
+		"description": "modjk_worker.disable:"
+	},
+	"modjk_worker.stop": {
+		"prefix": "modjk_worker.stop:",
+		"body": [
+			"modjk_worker.stop:",
+			"$0"
+		],
+		"description": "modjk_worker.stop:"
+	}
+}

--- a/snippets/modjk_worker.json
+++ b/snippets/modjk_worker.json
@@ -1,13 +1,4 @@
 {
-	"modjk_worker state": {
-		"prefix": [
-			"modjk_worker."
-		],
-		"body": [
-			"modjk_worker.${1|activate,disable,stop|}:"
-		],
-		"description": "modjk_worker state"
-	},
 	"modjk_worker.activate": {
 		"prefix": "modjk_worker.activate:",
 		"body": [

--- a/snippets/module.json
+++ b/snippets/module.json
@@ -1,0 +1,35 @@
+{
+	"module state": {
+		"prefix": [
+			"module."
+		],
+		"body": [
+			"module.${1|run,wait,watch|}:"
+		],
+		"description": "module state"
+	},
+	"module.run": {
+		"prefix": "module.run:",
+		"body": [
+			"module.run:",
+			"$0"
+		],
+		"description": "module.run:"
+	},
+	"module.wait": {
+		"prefix": "module.wait:",
+		"body": [
+			"module.wait:",
+			"$0"
+		],
+		"description": "module.wait:"
+	},
+	"module.watch": {
+		"prefix": "module.watch:",
+		"body": [
+			"module.watch:",
+			"$0"
+		],
+		"description": "module.watch:"
+	}
+}

--- a/snippets/module.json
+++ b/snippets/module.json
@@ -1,13 +1,4 @@
 {
-	"module state": {
-		"prefix": [
-			"module."
-		],
-		"body": [
-			"module.${1|run,wait,watch|}:"
-		],
-		"description": "module state"
-	},
 	"module.run": {
 		"prefix": "module.run:",
 		"body": [

--- a/snippets/mongodb_database.json
+++ b/snippets/mongodb_database.json
@@ -1,0 +1,10 @@
+{
+	"mongodb_database.absent": {
+		"prefix": "mongodb_database.absent:",
+		"body": [
+			"mongodb_database.absent:",
+			"$0"
+		],
+		"description": "mongodb_database.absent:"
+	}
+}

--- a/snippets/mongodb_user.json
+++ b/snippets/mongodb_user.json
@@ -1,0 +1,18 @@
+{
+	"mongodb_user.absent": {
+		"prefix": "mongodb_user.absent:",
+		"body": [
+			"mongodb_user.absent:",
+			"$0"
+		],
+		"description": "mongodb_user.absent:"
+	},
+	"mongodb_user.present": {
+		"prefix": "mongodb_user.present:",
+		"body": [
+			"mongodb_user.present:",
+			"$0"
+		],
+		"description": "mongodb_user.present:"
+	}
+}

--- a/snippets/mount.json
+++ b/snippets/mount.json
@@ -1,13 +1,4 @@
 {
-	"mount state": {
-		"prefix": [
-			"mount."
-		],
-		"body": [
-			"mount.${1|fstab_absent,fstab_present,mounted,swap,unmounted|}:"
-		],
-		"description": "mount state"
-	},
 	"mount.fstab_absent": {
 		"prefix": "mount.fstab_absent:",
 		"body": [

--- a/snippets/mount.json
+++ b/snippets/mount.json
@@ -1,0 +1,51 @@
+{
+	"mount state": {
+		"prefix": [
+			"mount."
+		],
+		"body": [
+			"mount.${1|fstab_absent,fstab_present,mounted,swap,unmounted|}:"
+		],
+		"description": "mount state"
+	},
+	"mount.fstab_absent": {
+		"prefix": "mount.fstab_absent:",
+		"body": [
+			"mount.fstab_absent:",
+			"$0"
+		],
+		"description": "mount.fstab_absent:"
+	},
+	"mount.fstab_present": {
+		"prefix": "mount.fstab_present:",
+		"body": [
+			"mount.fstab_present:",
+			"$0"
+		],
+		"description": "mount.fstab_present:"
+	},
+	"mount.mounted": {
+		"prefix": "mount.mounted:",
+		"body": [
+			"mount.mounted:",
+			"$0"
+		],
+		"description": "mount.mounted:"
+	},
+	"mount.swap": {
+		"prefix": "mount.swap:",
+		"body": [
+			"mount.swap:",
+			"$0"
+		],
+		"description": "mount.swap:"
+	},
+	"mount.unmounted": {
+		"prefix": "mount.unmounted:",
+		"body": [
+			"mount.unmounted:",
+			"$0"
+		],
+		"description": "mount.unmounted:"
+	}
+}

--- a/snippets/mssql_database.json
+++ b/snippets/mssql_database.json
@@ -1,0 +1,18 @@
+{
+	"mssql_database.present": {
+		"body": [
+			"mssql_database.present:",
+			"$0"
+		],
+		"prefix": "mssql_database.present:",
+		"description": "mssql_database.present:"
+	},
+	"mssql_database.absent": {
+		"body": [
+			"mssql_database.absent:",
+			"$0"
+		],
+		"prefix": "mssql_database.absent:",
+		"description": "mssql_database.absent:"
+	}
+}

--- a/snippets/mssql_login.json
+++ b/snippets/mssql_login.json
@@ -1,0 +1,18 @@
+{
+	"mssql_login.absent": {
+		"body": [
+			"mssql_login.absent:",
+			"$0"
+		],
+		"prefix": "mssql_login.absent:",
+		"description": "mssql_login.absent:"
+	},
+	"mssql_login.present": {
+		"body": [
+			"mssql_login.present:",
+			"$0"
+		],
+		"prefix": "mssql_login.present:",
+		"description": "mssql_login.present:"
+	}
+}

--- a/snippets/mssql_role.json
+++ b/snippets/mssql_role.json
@@ -1,0 +1,18 @@
+{
+	"mssql_role.absent": {
+		"body": [
+			"mssql_role.absent:",
+			"$0"
+		],
+		"prefix": "mssql_role.absent:",
+		"description": "mssql_role.absent:"
+	},
+	"mssql_role.present": {
+		"body": [
+			"mssql_role.present:",
+			"$0"
+		],
+		"prefix": "mssql_role.present:",
+		"description": "mssql_role.present:"
+	}
+}

--- a/snippets/mssql_user.json
+++ b/snippets/mssql_user.json
@@ -1,0 +1,18 @@
+{
+	"mssql_user.absent": {
+		"body": [
+			"mssql_user.absent:",
+			"$0"
+		],
+		"prefix": "mssql_user.absent:",
+		"description": "mssql_user.absent:"
+	},
+	"mssql_user.present": {
+		"body": [
+			"mssql_user.present:",
+			"$0"
+		],
+		"prefix": "mssql_user.present:",
+		"description": "mssql_user.present:"
+	}
+}

--- a/snippets/msteams.json
+++ b/snippets/msteams.json
@@ -1,13 +1,4 @@
 {
-	"msteams state": {
-		"prefix": [
-			"msteams."
-		],
-		"body": [
-			"msteams.${1|post_card|}:"
-		],
-		"description": "msteams state"
-	},
 	"msteams.post_card": {
 		"prefix": "msteams.post_card:",
 		"body": [

--- a/snippets/msteams.json
+++ b/snippets/msteams.json
@@ -1,0 +1,19 @@
+{
+	"msteams state": {
+		"prefix": [
+			"msteams."
+		],
+		"body": [
+			"msteams.${1|post_card|}:"
+		],
+		"description": "msteams state"
+	},
+	"msteams.post_card": {
+		"prefix": "msteams.post_card:",
+		"body": [
+			"msteams.post_card:",
+			"$0"
+		],
+		"description": "msteams.post_card:"
+	}
+}

--- a/snippets/mysql_database.json
+++ b/snippets/mysql_database.json
@@ -1,0 +1,18 @@
+{
+	"mysql_database.absent": {
+		"body": [
+			"mysql_database.absent:",
+			"$0"
+		],
+		"prefix": "mysql_database.absent:",
+		"description": "mysql_database.absent:"
+	},
+	"mysql_database.present": {
+		"body": [
+			"mysql_database.present:",
+			"$0"
+		],
+		"prefix": "mysql_database.present:",
+		"description": "mysql_database.present:"
+	}
+}

--- a/snippets/mysql_grants.json
+++ b/snippets/mysql_grants.json
@@ -1,0 +1,18 @@
+{
+	"mysql_grants.absent": {
+		"body": [
+			"mysql_grants.absent:",
+			"$0"
+		],
+		"prefix": "mysql_grants.absent:",
+		"description": "mysql_grants.absent:"
+	},
+	"mysql_grants.present": {
+		"body": [
+			"mysql_grants.present:",
+			"$0"
+		],
+		"prefix": "mysql_grants.present:",
+		"description": "mysql_grants.present:"
+	}
+}

--- a/snippets/mysql_query.json
+++ b/snippets/mysql_query.json
@@ -1,0 +1,18 @@
+{
+	"mysql_query.run_file": {
+		"body": [
+			"mysql_query.run_file:",
+			"$0"
+		],
+		"prefix": "mysql_query.run_file:",
+		"description": "mysql_query.run_file:"
+	},
+	"mysql_query.run": {
+		"body": [
+			"mysql_query.run:",
+			"$0"
+		],
+		"prefix": "mysql_query.run:",
+		"description": "mysql_query.run:"
+	}
+}

--- a/snippets/mysql_user.json
+++ b/snippets/mysql_user.json
@@ -1,0 +1,18 @@
+{
+	"mysql_user.present": {
+		"body": [
+			"mysql_user.present:",
+			"$0"
+		],
+		"prefix": "mysql_user.present:",
+		"description": "mysql_user.present:"
+	},
+	"mysql_user.absent": {
+		"body": [
+			"mysql_user.absent:",
+			"$0"
+		],
+		"prefix": "mysql_user.absent:",
+		"description": "mysql_user.absent:"
+	}
+}

--- a/snippets/network.json
+++ b/snippets/network.json
@@ -1,0 +1,10 @@
+{
+	"network.managed": {
+		"body": [
+			"network.managed:",
+			"$0"
+		],
+		"prefix": "network.managed:",
+		"description": "network.managed:"
+	}
+}

--- a/snippets/nexus.json
+++ b/snippets/nexus.json
@@ -1,0 +1,19 @@
+{
+	"nexus state": {
+		"prefix": [
+			"nexus."
+		],
+		"body": [
+			"nexus.${1|downloaded|}:"
+		],
+		"description": "nexus state"
+	},
+	"nexus.downloaded": {
+		"prefix": "nexus.downloaded:",
+		"body": [
+			"nexus.downloaded:",
+			"$0"
+		],
+		"description": "nexus.downloaded:"
+	}
+}

--- a/snippets/nexus.json
+++ b/snippets/nexus.json
@@ -1,13 +1,4 @@
 {
-	"nexus state": {
-		"prefix": [
-			"nexus."
-		],
-		"body": [
-			"nexus.${1|downloaded|}:"
-		],
-		"description": "nexus state"
-	},
 	"nexus.downloaded": {
 		"prefix": "nexus.downloaded:",
 		"body": [

--- a/snippets/npm.json
+++ b/snippets/npm.json
@@ -1,0 +1,43 @@
+{
+	"npm state": {
+		"prefix": [
+			"npm."
+		],
+		"body": [
+			"npm.${1|bootstrap,cache_cleaned,installed,removed|}:"
+		],
+		"description": "npm state"
+	},
+	"npm.bootstrap": {
+		"prefix": "npm.bootstrap:",
+		"body": [
+			"npm.bootstrap:",
+			"$0"
+		],
+		"description": "npm.bootstrap:"
+	},
+	"npm.cache_cleaned": {
+		"prefix": "npm.cache_cleaned:",
+		"body": [
+			"npm.cache_cleaned:",
+			"$0"
+		],
+		"description": "npm.cache_cleaned:"
+	},
+	"npm.installed": {
+		"prefix": "npm.installed:",
+		"body": [
+			"npm.installed:",
+			"$0"
+		],
+		"description": "npm.installed:"
+	},
+	"npm.removed": {
+		"prefix": "npm.removed:",
+		"body": [
+			"npm.removed:",
+			"$0"
+		],
+		"description": "npm.removed:"
+	}
+}

--- a/snippets/npm.json
+++ b/snippets/npm.json
@@ -1,13 +1,4 @@
 {
-	"npm state": {
-		"prefix": [
-			"npm."
-		],
-		"body": [
-			"npm.${1|bootstrap,cache_cleaned,installed,removed|}:"
-		],
-		"description": "npm state"
-	},
 	"npm.bootstrap": {
 		"prefix": "npm.bootstrap:",
 		"body": [

--- a/snippets/ntp.json
+++ b/snippets/ntp.json
@@ -1,0 +1,10 @@
+{
+	"ntp.managed": {
+		"body": [
+			"ntp.managed:",
+			"$0"
+		],
+		"prefix": "ntp.managed:",
+		"description": "ntp.managed:"
+	}
+}

--- a/snippets/openstack_config.json
+++ b/snippets/openstack_config.json
@@ -1,13 +1,4 @@
 {
-	"openstack_config state": {
-		"prefix": [
-			"openstack_config."
-		],
-		"body": [
-			"openstack_config.${1|absent,present|}:"
-		],
-		"description": "openstack_config state"
-	},
 	"openstack_config.absent": {
 		"prefix": "openstack_config.absent:",
 		"body": [

--- a/snippets/openstack_config.json
+++ b/snippets/openstack_config.json
@@ -1,0 +1,27 @@
+{
+	"openstack_config state": {
+		"prefix": [
+			"openstack_config."
+		],
+		"body": [
+			"openstack_config.${1|absent,present|}:"
+		],
+		"description": "openstack_config state"
+	},
+	"openstack_config.absent": {
+		"prefix": "openstack_config.absent:",
+		"body": [
+			"openstack_config.absent:",
+			"$0"
+		],
+		"description": "openstack_config.absent:"
+	},
+	"openstack_config.present": {
+		"prefix": "openstack_config.present:",
+		"body": [
+			"openstack_config.present:",
+			"$0"
+		],
+		"description": "openstack_config.present:"
+	}
+}

--- a/snippets/opsgenie.json
+++ b/snippets/opsgenie.json
@@ -1,0 +1,27 @@
+{
+	"opsgenie state": {
+		"prefix": [
+			"opsgenie."
+		],
+		"body": [
+			"opsgenie.${1|close_alert,create_alert|}:"
+		],
+		"description": "opsgenie state"
+	},
+	"opsgenie.close_alert": {
+		"prefix": "opsgenie.close_alert:",
+		"body": [
+			"opsgenie.close_alert:",
+			"$0"
+		],
+		"description": "opsgenie.close_alert:"
+	},
+	"opsgenie.create_alert": {
+		"prefix": "opsgenie.create_alert:",
+		"body": [
+			"opsgenie.create_alert:",
+			"$0"
+		],
+		"description": "opsgenie.create_alert:"
+	}
+}

--- a/snippets/opsgenie.json
+++ b/snippets/opsgenie.json
@@ -1,13 +1,4 @@
 {
-	"opsgenie state": {
-		"prefix": [
-			"opsgenie."
-		],
-		"body": [
-			"opsgenie.${1|close_alert,create_alert|}:"
-		],
-		"description": "opsgenie state"
-	},
 	"opsgenie.close_alert": {
 		"prefix": "opsgenie.close_alert:",
 		"body": [

--- a/snippets/pagerduty.json
+++ b/snippets/pagerduty.json
@@ -1,0 +1,19 @@
+{
+	"pagerduty state": {
+		"prefix": [
+			"pagerduty."
+		],
+		"body": [
+			"pagerduty.${1|create_event|}:"
+		],
+		"description": "pagerduty state"
+	},
+	"pagerduty.create_event": {
+		"prefix": "pagerduty.create_event:",
+		"body": [
+			"pagerduty.create_event:",
+			"$0"
+		],
+		"description": "pagerduty.create_event:"
+	}
+}

--- a/snippets/pagerduty.json
+++ b/snippets/pagerduty.json
@@ -1,13 +1,4 @@
 {
-	"pagerduty state": {
-		"prefix": [
-			"pagerduty."
-		],
-		"body": [
-			"pagerduty.${1|create_event|}:"
-		],
-		"description": "pagerduty state"
-	},
 	"pagerduty.create_event": {
 		"prefix": "pagerduty.create_event:",
 		"body": [

--- a/snippets/pagerduty_escalation_policy.json
+++ b/snippets/pagerduty_escalation_policy.json
@@ -1,0 +1,27 @@
+{
+	"pagerduty_escalation_policy state": {
+		"prefix": [
+			"pagerduty_escalation_policy."
+		],
+		"body": [
+			"pagerduty_escalation_policy.${1|absent,present|}:"
+		],
+		"description": "pagerduty_escalation_policy state"
+	},
+	"pagerduty_escalation_policy.absent": {
+		"prefix": "pagerduty_escalation_policy.absent:",
+		"body": [
+			"pagerduty_escalation_policy.absent:",
+			"$0"
+		],
+		"description": "pagerduty_escalation_policy.absent:"
+	},
+	"pagerduty_escalation_policy.present": {
+		"prefix": "pagerduty_escalation_policy.present:",
+		"body": [
+			"pagerduty_escalation_policy.present:",
+			"$0"
+		],
+		"description": "pagerduty_escalation_policy.present:"
+	}
+}

--- a/snippets/pagerduty_escalation_policy.json
+++ b/snippets/pagerduty_escalation_policy.json
@@ -1,13 +1,4 @@
 {
-	"pagerduty_escalation_policy state": {
-		"prefix": [
-			"pagerduty_escalation_policy."
-		],
-		"body": [
-			"pagerduty_escalation_policy.${1|absent,present|}:"
-		],
-		"description": "pagerduty_escalation_policy state"
-	},
 	"pagerduty_escalation_policy.absent": {
 		"prefix": "pagerduty_escalation_policy.absent:",
 		"body": [

--- a/snippets/pagerduty_schedule.json
+++ b/snippets/pagerduty_schedule.json
@@ -1,0 +1,27 @@
+{
+	"pagerduty_schedule state": {
+		"prefix": [
+			"pagerduty_schedule."
+		],
+		"body": [
+			"pagerduty_schedule.${1|absent,present|}:"
+		],
+		"description": "pagerduty_schedule state"
+	},
+	"pagerduty_schedule.absent": {
+		"prefix": "pagerduty_schedule.absent:",
+		"body": [
+			"pagerduty_schedule.absent:",
+			"$0"
+		],
+		"description": "pagerduty_schedule.absent:"
+	},
+	"pagerduty_schedule.present": {
+		"prefix": "pagerduty_schedule.present:",
+		"body": [
+			"pagerduty_schedule.present:",
+			"$0"
+		],
+		"description": "pagerduty_schedule.present:"
+	}
+}

--- a/snippets/pagerduty_schedule.json
+++ b/snippets/pagerduty_schedule.json
@@ -1,13 +1,4 @@
 {
-	"pagerduty_schedule state": {
-		"prefix": [
-			"pagerduty_schedule."
-		],
-		"body": [
-			"pagerduty_schedule.${1|absent,present|}:"
-		],
-		"description": "pagerduty_schedule state"
-	},
 	"pagerduty_schedule.absent": {
 		"prefix": "pagerduty_schedule.absent:",
 		"body": [

--- a/snippets/pagerduty_service.json
+++ b/snippets/pagerduty_service.json
@@ -1,0 +1,27 @@
+{
+	"pagerduty_service state": {
+		"prefix": [
+			"pagerduty_service."
+		],
+		"body": [
+			"pagerduty_service.${1|absent,present|}:"
+		],
+		"description": "pagerduty_service state"
+	},
+	"pagerduty_service.absent": {
+		"prefix": "pagerduty_service.absent:",
+		"body": [
+			"pagerduty_service.absent:",
+			"$0"
+		],
+		"description": "pagerduty_service.absent:"
+	},
+	"pagerduty_service.present": {
+		"prefix": "pagerduty_service.present:",
+		"body": [
+			"pagerduty_service.present:",
+			"$0"
+		],
+		"description": "pagerduty_service.present:"
+	}
+}

--- a/snippets/pagerduty_service.json
+++ b/snippets/pagerduty_service.json
@@ -1,13 +1,4 @@
 {
-	"pagerduty_service state": {
-		"prefix": [
-			"pagerduty_service."
-		],
-		"body": [
-			"pagerduty_service.${1|absent,present|}:"
-		],
-		"description": "pagerduty_service state"
-	},
 	"pagerduty_service.absent": {
 		"prefix": "pagerduty_service.absent:",
 		"body": [

--- a/snippets/pagerduty_user.json
+++ b/snippets/pagerduty_user.json
@@ -1,13 +1,4 @@
 {
-	"pagerduty_user state": {
-		"prefix": [
-			"pagerduty_user."
-		],
-		"body": [
-			"pagerduty_user.${1|absent,present|}:"
-		],
-		"description": "pagerduty_user state"
-	},
 	"pagerduty_user.absent": {
 		"prefix": "pagerduty_user.absent:",
 		"body": [

--- a/snippets/pagerduty_user.json
+++ b/snippets/pagerduty_user.json
@@ -1,0 +1,27 @@
+{
+	"pagerduty_user state": {
+		"prefix": [
+			"pagerduty_user."
+		],
+		"body": [
+			"pagerduty_user.${1|absent,present|}:"
+		],
+		"description": "pagerduty_user state"
+	},
+	"pagerduty_user.absent": {
+		"prefix": "pagerduty_user.absent:",
+		"body": [
+			"pagerduty_user.absent:",
+			"$0"
+		],
+		"description": "pagerduty_user.absent:"
+	},
+	"pagerduty_user.present": {
+		"prefix": "pagerduty_user.present:",
+		"body": [
+			"pagerduty_user.present:",
+			"$0"
+		],
+		"description": "pagerduty_user.present:"
+	}
+}

--- a/snippets/pbm.json
+++ b/snippets/pbm.json
@@ -1,0 +1,50 @@
+{
+	"pbm.default_storage_policy_assigned": {
+		"prefix": "pbm.default_storage_policy_assigned:",
+		"body": [
+			"pbm.default_storage_policy_assigned:",
+			"$0"
+		],
+		"description": "pbm.default_storage_policy_assigned:"
+	},
+	"pbm.default_vsan_policy_configured": {
+		"prefix": "pbm.default_vsan_policy_configured:",
+		"body": [
+			"pbm.default_vsan_policy_configured:",
+			"$0"
+		],
+		"description": "pbm.default_vsan_policy_configured:"
+	},
+	"pbm.list_diff": {
+		"prefix": "pbm.list_diff:",
+		"body": [
+			"pbm.list_diff:",
+			"$0"
+		],
+		"description": "pbm.list_diff:"
+	},
+	"pbm.mod_init": {
+		"prefix": "pbm.mod_init:",
+		"body": [
+			"pbm.mod_init:",
+			"$0"
+		],
+		"description": "pbm.mod_init:"
+	},
+	"pbm.recursive_diff": {
+		"prefix": "pbm.recursive_diff:",
+		"body": [
+			"pbm.recursive_diff:",
+			"$0"
+		],
+		"description": "pbm.recursive_diff:"
+	},
+	"pbm.storage_policies_configured": {
+		"prefix": "pbm.storage_policies_configured:",
+		"body": [
+			"pbm.storage_policies_configured:",
+			"$0"
+		],
+		"description": "pbm.storage_policies_configured:"
+	}
+}

--- a/snippets/pip.json
+++ b/snippets/pip.json
@@ -1,0 +1,59 @@
+{
+	"pip state": {
+		"prefix": [
+			"pip."
+		],
+		"body": [
+			"pip.${1|installed,pip_has_exceptions_mod,pip_has_internal_exceptions_mod,purge_pip,removed,uptodate|}:"
+		],
+		"description": "pip state"
+	},
+	"pip.installed": {
+		"prefix": "pip.installed:",
+		"body": [
+			"pip.installed:",
+			"$0"
+		],
+		"description": "pip.installed:"
+	},
+	"pip.pip_has_exceptions_mod": {
+		"prefix": "pip.pip_has_exceptions_mod:",
+		"body": [
+			"pip.pip_has_exceptions_mod:",
+			"$0"
+		],
+		"description": "pip.pip_has_exceptions_mod:"
+	},
+	"pip.pip_has_internal_exceptions_mod": {
+		"prefix": "pip.pip_has_internal_exceptions_mod:",
+		"body": [
+			"pip.pip_has_internal_exceptions_mod:",
+			"$0"
+		],
+		"description": "pip.pip_has_internal_exceptions_mod:"
+	},
+	"pip.purge_pip": {
+		"prefix": "pip.purge_pip:",
+		"body": [
+			"pip.purge_pip:",
+			"$0"
+		],
+		"description": "pip.purge_pip:"
+	},
+	"pip.removed": {
+		"prefix": "pip.removed:",
+		"body": [
+			"pip.removed:",
+			"$0"
+		],
+		"description": "pip.removed:"
+	},
+	"pip.uptodate": {
+		"prefix": "pip.uptodate:",
+		"body": [
+			"pip.uptodate:",
+			"$0"
+		],
+		"description": "pip.uptodate:"
+	}
+}

--- a/snippets/pip.json
+++ b/snippets/pip.json
@@ -1,13 +1,4 @@
 {
-	"pip state": {
-		"prefix": [
-			"pip."
-		],
-		"body": [
-			"pip.${1|installed,pip_has_exceptions_mod,pip_has_internal_exceptions_mod,purge_pip,removed,uptodate|}:"
-		],
-		"description": "pip state"
-	},
 	"pip.installed": {
 		"prefix": "pip.installed:",
 		"body": [

--- a/snippets/pkg.json
+++ b/snippets/pkg.json
@@ -1,0 +1,114 @@
+{
+	"pkg.downloaded": {
+		"body": [
+			"pkg.downloaded:",
+			"$0"
+		],
+		"prefix": "pkg.downloaded:",
+		"description": "pkg.downloaded:"
+	},
+	"pkg.group_installed": {
+		"body": [
+			"pkg.group_installed:",
+			"$0"
+		],
+		"prefix": "pkg.group_installed:",
+		"description": "pkg.group_installed:"
+	},
+	"pkg.mod_aggregate": {
+		"body": [
+			"pkg.mod_aggregate:",
+			"$0"
+		],
+		"prefix": "pkg.mod_aggregate:",
+		"description": "pkg.mod_aggregate:"
+	},
+	"pkg.mod_init": {
+		"body": [
+			"pkg.mod_init:",
+			"$0"
+		],
+		"prefix": "pkg.mod_init:",
+		"description": "pkg.mod_init:"
+	},
+	"pkg.latest": {
+		"body": [
+			"pkg.latest:",
+			"$0"
+		],
+		"prefix": "pkg.latest:",
+		"description": "pkg.latest:"
+	},
+	"pkg.patch_downloaded": {
+		"body": [
+			"pkg.patch_downloaded:",
+			"$0"
+		],
+		"prefix": "pkg.patch_downloaded:",
+		"description": "pkg.patch_downloaded:"
+	},
+	"pkg.get_repo_data": {
+		"body": [
+			"pkg.get_repo_data:",
+			"$0"
+		],
+		"prefix": "pkg.get_repo_data:",
+		"description": "pkg.get_repo_data:"
+	},
+	"pkg.refresh_db": {
+		"body": [
+			"pkg.refresh_db:",
+			"$0"
+		],
+		"prefix": "pkg.refresh_db:",
+		"description": "pkg.refresh_db:"
+	},
+	"pkg.uptodate": {
+		"body": [
+			"pkg.uptodate:",
+			"$0"
+		],
+		"prefix": "pkg.uptodate:",
+		"description": "pkg.uptodate:"
+	},
+	"pkg.patch_installed": {
+		"body": [
+			"pkg.patch_installed:",
+			"$0"
+		],
+		"prefix": "pkg.patch_installed:",
+		"description": "pkg.patch_installed:"
+	},
+	"pkg.purged": {
+		"body": [
+			"pkg.purged:",
+			"$0"
+		],
+		"prefix": "pkg.purged:",
+		"description": "pkg.purged:"
+	},
+	"pkg.genrepo": {
+		"body": [
+			"pkg.genrepo:",
+			"$0"
+		],
+		"prefix": "pkg.genrepo:",
+		"description": "pkg.genrepo:"
+	},
+	"pkg.removed": {
+		"body": [
+			"pkg.removed:",
+			"$0"
+		],
+		"prefix": "pkg.removed:",
+		"description": "pkg.removed:"
+	},
+	"pkg.installed": {
+		"body": [
+			"pkg.installed:",
+			"$0"
+		],
+		"prefix": "pkg.installed:",
+		"description": "pkg.installed:"
+	}
+}

--- a/snippets/pkgbuild.json
+++ b/snippets/pkgbuild.json
@@ -1,0 +1,27 @@
+{
+	"pkgbuild state": {
+		"prefix": [
+			"pkgbuild."
+		],
+		"body": [
+			"pkgbuild.${1|built,repo|}:"
+		],
+		"description": "pkgbuild state"
+	},
+	"pkgbuild.built": {
+		"prefix": "pkgbuild.built:",
+		"body": [
+			"pkgbuild.built:",
+			"$0"
+		],
+		"description": "pkgbuild.built:"
+	},
+	"pkgbuild.repo": {
+		"prefix": "pkgbuild.repo:",
+		"body": [
+			"pkgbuild.repo:",
+			"$0"
+		],
+		"description": "pkgbuild.repo:"
+	}
+}

--- a/snippets/pkgbuild.json
+++ b/snippets/pkgbuild.json
@@ -1,13 +1,4 @@
 {
-	"pkgbuild state": {
-		"prefix": [
-			"pkgbuild."
-		],
-		"body": [
-			"pkgbuild.${1|built,repo|}:"
-		],
-		"description": "pkgbuild state"
-	},
 	"pkgbuild.built": {
 		"prefix": "pkgbuild.built:",
 		"body": [

--- a/snippets/pkgng.json
+++ b/snippets/pkgng.json
@@ -1,13 +1,4 @@
 {
-	"pkgng state": {
-		"prefix": [
-			"pkgng."
-		],
-		"body": [
-			"pkgng.${1|update_packaging_site|}:"
-		],
-		"description": "pkgng state"
-	},
 	"pkgng.update_packaging_site": {
 		"prefix": "pkgng.update_packaging_site:",
 		"body": [

--- a/snippets/pkgng.json
+++ b/snippets/pkgng.json
@@ -1,0 +1,19 @@
+{
+	"pkgng state": {
+		"prefix": [
+			"pkgng."
+		],
+		"body": [
+			"pkgng.${1|update_packaging_site|}:"
+		],
+		"description": "pkgng state"
+	},
+	"pkgng.update_packaging_site": {
+		"prefix": "pkgng.update_packaging_site:",
+		"body": [
+			"pkgng.update_packaging_site:",
+			"$0"
+		],
+		"description": "pkgng.update_packaging_site:"
+	}
+}

--- a/snippets/powercfg.json
+++ b/snippets/powercfg.json
@@ -1,0 +1,10 @@
+{
+	"powercfg.set_timeout": {
+		"body": [
+			"powercfg.set_timeout:",
+			"$0"
+		],
+		"prefix": "powercfg.set_timeout:",
+		"description": "powercfg.set_timeout:"
+	}
+}

--- a/snippets/powerpath.json
+++ b/snippets/powerpath.json
@@ -1,13 +1,4 @@
 {
-	"powerpath state": {
-		"prefix": [
-			"powerpath."
-		],
-		"body": [
-			"powerpath.${1|license_absent,license_present|}:"
-		],
-		"description": "powerpath state"
-	},
 	"powerpath.license_absent": {
 		"prefix": "powerpath.license_absent:",
 		"body": [

--- a/snippets/powerpath.json
+++ b/snippets/powerpath.json
@@ -1,0 +1,27 @@
+{
+	"powerpath state": {
+		"prefix": [
+			"powerpath."
+		],
+		"body": [
+			"powerpath.${1|license_absent,license_present|}:"
+		],
+		"description": "powerpath state"
+	},
+	"powerpath.license_absent": {
+		"prefix": "powerpath.license_absent:",
+		"body": [
+			"powerpath.license_absent:",
+			"$0"
+		],
+		"description": "powerpath.license_absent:"
+	},
+	"powerpath.license_present": {
+		"prefix": "powerpath.license_present:",
+		"body": [
+			"powerpath.license_present:",
+			"$0"
+		],
+		"description": "powerpath.license_present:"
+	}
+}

--- a/snippets/process.json
+++ b/snippets/process.json
@@ -1,13 +1,4 @@
 {
-	"process state": {
-		"prefix": [
-			"process."
-		],
-		"body": [
-			"process.${1|absent|}:"
-		],
-		"description": "process state"
-	},
 	"process.absent": {
 		"prefix": "process.absent:",
 		"body": [

--- a/snippets/process.json
+++ b/snippets/process.json
@@ -1,0 +1,19 @@
+{
+	"process state": {
+		"prefix": [
+			"process."
+		],
+		"body": [
+			"process.${1|absent|}:"
+		],
+		"description": "process state"
+	},
+	"process.absent": {
+		"prefix": "process.absent:",
+		"body": [
+			"process.absent:",
+			"$0"
+		],
+		"description": "process.absent:"
+	}
+}

--- a/snippets/proxy.json
+++ b/snippets/proxy.json
@@ -1,0 +1,10 @@
+{
+	"proxy.managed": {
+		"body": [
+			"proxy.managed:",
+			"$0"
+		],
+		"prefix": "proxy.managed:",
+		"description": "proxy.managed:"
+	}
+}

--- a/snippets/pushover.json
+++ b/snippets/pushover.json
@@ -1,0 +1,19 @@
+{
+	"pushover state": {
+		"prefix": [
+			"pushover."
+		],
+		"body": [
+			"pushover.${1|post_message|}:"
+		],
+		"description": "pushover state"
+	},
+	"pushover.post_message": {
+		"prefix": "pushover.post_message:",
+		"body": [
+			"pushover.post_message:",
+			"$0"
+		],
+		"description": "pushover.post_message:"
+	}
+}

--- a/snippets/pushover.json
+++ b/snippets/pushover.json
@@ -1,13 +1,4 @@
 {
-	"pushover state": {
-		"prefix": [
-			"pushover."
-		],
-		"body": [
-			"pushover.${1|post_message|}:"
-		],
-		"description": "pushover state"
-	},
 	"pushover.post_message": {
 		"prefix": "pushover.post_message:",
 		"body": [

--- a/snippets/pyenv.json
+++ b/snippets/pyenv.json
@@ -1,0 +1,35 @@
+{
+	"pyenv state": {
+		"prefix": [
+			"pyenv."
+		],
+		"body": [
+			"pyenv.${1|absent,install_pyenv,installed|}:"
+		],
+		"description": "pyenv state"
+	},
+	"pyenv.absent": {
+		"prefix": "pyenv.absent:",
+		"body": [
+			"pyenv.absent:",
+			"$0"
+		],
+		"description": "pyenv.absent:"
+	},
+	"pyenv.install_pyenv": {
+		"prefix": "pyenv.install_pyenv:",
+		"body": [
+			"pyenv.install_pyenv:",
+			"$0"
+		],
+		"description": "pyenv.install_pyenv:"
+	},
+	"pyenv.installed": {
+		"prefix": "pyenv.installed:",
+		"body": [
+			"pyenv.installed:",
+			"$0"
+		],
+		"description": "pyenv.installed:"
+	}
+}

--- a/snippets/pyenv.json
+++ b/snippets/pyenv.json
@@ -1,13 +1,4 @@
 {
-	"pyenv state": {
-		"prefix": [
-			"pyenv."
-		],
-		"body": [
-			"pyenv.${1|absent,install_pyenv,installed|}:"
-		],
-		"description": "pyenv state"
-	},
 	"pyenv.absent": {
 		"prefix": "pyenv.absent:",
 		"body": [

--- a/snippets/rbenv.json
+++ b/snippets/rbenv.json
@@ -1,13 +1,4 @@
 {
-	"rbenv state": {
-		"prefix": [
-			"rbenv."
-		],
-		"body": [
-			"rbenv.${1|absent,install_rbenv,installed|}:"
-		],
-		"description": "rbenv state"
-	},
 	"rbenv.absent": {
 		"prefix": "rbenv.absent:",
 		"body": [

--- a/snippets/rbenv.json
+++ b/snippets/rbenv.json
@@ -1,0 +1,35 @@
+{
+	"rbenv state": {
+		"prefix": [
+			"rbenv."
+		],
+		"body": [
+			"rbenv.${1|absent,install_rbenv,installed|}:"
+		],
+		"description": "rbenv state"
+	},
+	"rbenv.absent": {
+		"prefix": "rbenv.absent:",
+		"body": [
+			"rbenv.absent:",
+			"$0"
+		],
+		"description": "rbenv.absent:"
+	},
+	"rbenv.install_rbenv": {
+		"prefix": "rbenv.install_rbenv:",
+		"body": [
+			"rbenv.install_rbenv:",
+			"$0"
+		],
+		"description": "rbenv.install_rbenv:"
+	},
+	"rbenv.installed": {
+		"prefix": "rbenv.installed:",
+		"body": [
+			"rbenv.installed:",
+			"$0"
+		],
+		"description": "rbenv.installed:"
+	}
+}

--- a/snippets/rdp.json
+++ b/snippets/rdp.json
@@ -1,0 +1,18 @@
+{
+	"rdp.enabled": {
+		"body": [
+			"rdp.enabled:",
+			"$0"
+		],
+		"prefix": "rdp.enabled:",
+		"description": "rdp.enabled:"
+	},
+	"rdp.disabled": {
+		"body": [
+			"rdp.disabled:",
+			"$0"
+		],
+		"prefix": "rdp.disabled:",
+		"description": "rdp.disabled:"
+	}
+}

--- a/snippets/reg.json
+++ b/snippets/reg.json
@@ -1,0 +1,26 @@
+{
+	"reg.absent": {
+		"body": [
+			"reg.absent:",
+			"$0"
+		],
+		"prefix": "reg.absent:",
+		"description": "reg.absent:"
+	},
+	"reg.present": {
+		"body": [
+			"reg.present:",
+			"$0"
+		],
+		"prefix": "reg.present:",
+		"description": "reg.present:"
+	},
+	"reg.key_absent": {
+		"body": [
+			"reg.key_absent:",
+			"$0"
+		],
+		"prefix": "reg.key_absent:",
+		"description": "reg.key_absent:"
+	}
+}

--- a/snippets/rsync.json
+++ b/snippets/rsync.json
@@ -1,0 +1,10 @@
+{
+	"rsync.synchronized": {
+		"prefix": "rsync.synchronized:",
+		"body": [
+			"rsync.synchronized:",
+			"$0"
+		],
+		"description": "rsync.synchronized:"
+	}
+}

--- a/snippets/rvm.json
+++ b/snippets/rvm.json
@@ -1,0 +1,27 @@
+{
+	"rvm state": {
+		"prefix": [
+			"rvm."
+		],
+		"body": [
+			"rvm.${1|gemset_present,installed|}:"
+		],
+		"description": "rvm state"
+	},
+	"rvm.gemset_present": {
+		"prefix": "rvm.gemset_present:",
+		"body": [
+			"rvm.gemset_present:",
+			"$0"
+		],
+		"description": "rvm.gemset_present:"
+	},
+	"rvm.installed": {
+		"prefix": "rvm.installed:",
+		"body": [
+			"rvm.installed:",
+			"$0"
+		],
+		"description": "rvm.installed:"
+	}
+}

--- a/snippets/rvm.json
+++ b/snippets/rvm.json
@@ -1,13 +1,4 @@
 {
-	"rvm state": {
-		"prefix": [
-			"rvm."
-		],
-		"body": [
-			"rvm.${1|gemset_present,installed|}:"
-		],
-		"description": "rvm state"
-	},
 	"rvm.gemset_present": {
 		"prefix": "rvm.gemset_present:",
 		"body": [

--- a/snippets/salt.json
+++ b/snippets/salt.json
@@ -1,13 +1,4 @@
 {
-	"salt state": {
-		"prefix": [
-			"salt."
-		],
-		"body": [
-			"salt.${1|function,parallel_runners,runner,state,wait_for_event,wheel|}:"
-		],
-		"description": "salt state"
-	},
 	"salt.function": {
 		"prefix": "salt.function:",
 		"body": [

--- a/snippets/salt.json
+++ b/snippets/salt.json
@@ -1,0 +1,59 @@
+{
+	"salt state": {
+		"prefix": [
+			"salt."
+		],
+		"body": [
+			"salt.${1|function,parallel_runners,runner,state,wait_for_event,wheel|}:"
+		],
+		"description": "salt state"
+	},
+	"salt.function": {
+		"prefix": "salt.function:",
+		"body": [
+			"salt.function:",
+			"$0"
+		],
+		"description": "salt.function:"
+	},
+	"salt.parallel_runners": {
+		"prefix": "salt.parallel_runners:",
+		"body": [
+			"salt.parallel_runners:",
+			"$0"
+		],
+		"description": "salt.parallel_runners:"
+	},
+	"salt.runner": {
+		"prefix": "salt.runner:",
+		"body": [
+			"salt.runner:",
+			"$0"
+		],
+		"description": "salt.runner:"
+	},
+	"salt.state": {
+		"prefix": "salt.state:",
+		"body": [
+			"salt.state:",
+			"$0"
+		],
+		"description": "salt.state:"
+	},
+	"salt.wait_for_event": {
+		"prefix": "salt.wait_for_event:",
+		"body": [
+			"salt.wait_for_event:",
+			"$0"
+		],
+		"description": "salt.wait_for_event:"
+	},
+	"salt.wheel": {
+		"prefix": "salt.wheel:",
+		"body": [
+			"salt.wheel:",
+			"$0"
+		],
+		"description": "salt.wheel:"
+	}
+}

--- a/snippets/salt_proxy.json
+++ b/snippets/salt_proxy.json
@@ -1,13 +1,4 @@
 {
-	"salt_proxy state": {
-		"prefix": [
-			"salt_proxy."
-		],
-		"body": [
-			"salt_proxy.${1|configure_proxy|}:"
-		],
-		"description": "salt_proxy state"
-	},
 	"salt_proxy.configure_proxy": {
 		"prefix": "salt_proxy.configure_proxy:",
 		"body": [

--- a/snippets/salt_proxy.json
+++ b/snippets/salt_proxy.json
@@ -1,0 +1,19 @@
+{
+	"salt_proxy state": {
+		"prefix": [
+			"salt_proxy."
+		],
+		"body": [
+			"salt_proxy.${1|configure_proxy|}:"
+		],
+		"description": "salt_proxy state"
+	},
+	"salt_proxy.configure_proxy": {
+		"prefix": "salt_proxy.configure_proxy:",
+		"body": [
+			"salt_proxy.configure_proxy:",
+			"$0"
+		],
+		"description": "salt_proxy.configure_proxy:"
+	}
+}

--- a/snippets/saltutil.json
+++ b/snippets/saltutil.json
@@ -1,0 +1,171 @@
+{
+	"saltutil state": {
+		"prefix": [
+			"saltutil."
+		],
+		"body": [
+			"saltutil.${1|sync_all,sync_beacons,sync_clouds,sync_engines,sync_executors,sync_grains,sync_log_handlers,sync_matchers,sync_modules,sync_output,sync_outputters,sync_pillar,sync_proxymodules,sync_renderers,sync_returners,sync_sdb,sync_serializers,sync_states,sync_thorium,sync_utils|}:"
+		],
+		"description": "saltutil state"
+	},
+	"saltutil.sync_all": {
+		"prefix": "saltutil.sync_all:",
+		"body": [
+			"saltutil.sync_all:",
+			"$0"
+		],
+		"description": "saltutil.sync_all:"
+	},
+	"saltutil.sync_beacons": {
+		"prefix": "saltutil.sync_beacons:",
+		"body": [
+			"saltutil.sync_beacons:",
+			"$0"
+		],
+		"description": "saltutil.sync_beacons:"
+	},
+	"saltutil.sync_clouds": {
+		"prefix": "saltutil.sync_clouds:",
+		"body": [
+			"saltutil.sync_clouds:",
+			"$0"
+		],
+		"description": "saltutil.sync_clouds:"
+	},
+	"saltutil.sync_engines": {
+		"prefix": "saltutil.sync_engines:",
+		"body": [
+			"saltutil.sync_engines:",
+			"$0"
+		],
+		"description": "saltutil.sync_engines:"
+	},
+	"saltutil.sync_executors": {
+		"prefix": "saltutil.sync_executors:",
+		"body": [
+			"saltutil.sync_executors:",
+			"$0"
+		],
+		"description": "saltutil.sync_executors:"
+	},
+	"saltutil.sync_grains": {
+		"prefix": "saltutil.sync_grains:",
+		"body": [
+			"saltutil.sync_grains:",
+			"$0"
+		],
+		"description": "saltutil.sync_grains:"
+	},
+	"saltutil.sync_log_handlers": {
+		"prefix": "saltutil.sync_log_handlers:",
+		"body": [
+			"saltutil.sync_log_handlers:",
+			"$0"
+		],
+		"description": "saltutil.sync_log_handlers:"
+	},
+	"saltutil.sync_matchers": {
+		"prefix": "saltutil.sync_matchers:",
+		"body": [
+			"saltutil.sync_matchers:",
+			"$0"
+		],
+		"description": "saltutil.sync_matchers:"
+	},
+	"saltutil.sync_modules": {
+		"prefix": "saltutil.sync_modules:",
+		"body": [
+			"saltutil.sync_modules:",
+			"$0"
+		],
+		"description": "saltutil.sync_modules:"
+	},
+	"saltutil.sync_output": {
+		"prefix": "saltutil.sync_output:",
+		"body": [
+			"saltutil.sync_output:",
+			"$0"
+		],
+		"description": "saltutil.sync_output:"
+	},
+	"saltutil.sync_outputters": {
+		"prefix": "saltutil.sync_outputters:",
+		"body": [
+			"saltutil.sync_outputters:",
+			"$0"
+		],
+		"description": "saltutil.sync_outputters:"
+	},
+	"saltutil.sync_pillar": {
+		"prefix": "saltutil.sync_pillar:",
+		"body": [
+			"saltutil.sync_pillar:",
+			"$0"
+		],
+		"description": "saltutil.sync_pillar:"
+	},
+	"saltutil.sync_proxymodules": {
+		"prefix": "saltutil.sync_proxymodules:",
+		"body": [
+			"saltutil.sync_proxymodules:",
+			"$0"
+		],
+		"description": "saltutil.sync_proxymodules:"
+	},
+	"saltutil.sync_renderers": {
+		"prefix": "saltutil.sync_renderers:",
+		"body": [
+			"saltutil.sync_renderers:",
+			"$0"
+		],
+		"description": "saltutil.sync_renderers:"
+	},
+	"saltutil.sync_returners": {
+		"prefix": "saltutil.sync_returners:",
+		"body": [
+			"saltutil.sync_returners:",
+			"$0"
+		],
+		"description": "saltutil.sync_returners:"
+	},
+	"saltutil.sync_sdb": {
+		"prefix": "saltutil.sync_sdb:",
+		"body": [
+			"saltutil.sync_sdb:",
+			"$0"
+		],
+		"description": "saltutil.sync_sdb:"
+	},
+	"saltutil.sync_serializers": {
+		"prefix": "saltutil.sync_serializers:",
+		"body": [
+			"saltutil.sync_serializers:",
+			"$0"
+		],
+		"description": "saltutil.sync_serializers:"
+	},
+	"saltutil.sync_states": {
+		"prefix": "saltutil.sync_states:",
+		"body": [
+			"saltutil.sync_states:",
+			"$0"
+		],
+		"description": "saltutil.sync_states:"
+	},
+	"saltutil.sync_thorium": {
+		"prefix": "saltutil.sync_thorium:",
+		"body": [
+			"saltutil.sync_thorium:",
+			"$0"
+		],
+		"description": "saltutil.sync_thorium:"
+	},
+	"saltutil.sync_utils": {
+		"prefix": "saltutil.sync_utils:",
+		"body": [
+			"saltutil.sync_utils:",
+			"$0"
+		],
+		"description": "saltutil.sync_utils:"
+	}
+}

--- a/snippets/saltutil.json
+++ b/snippets/saltutil.json
@@ -1,13 +1,4 @@
 {
-	"saltutil state": {
-		"prefix": [
-			"saltutil."
-		],
-		"body": [
-			"saltutil.${1|sync_all,sync_beacons,sync_clouds,sync_engines,sync_executors,sync_grains,sync_log_handlers,sync_matchers,sync_modules,sync_output,sync_outputters,sync_pillar,sync_proxymodules,sync_renderers,sync_returners,sync_sdb,sync_serializers,sync_states,sync_thorium,sync_utils|}:"
-		],
-		"description": "saltutil state"
-	},
 	"saltutil.sync_all": {
 		"prefix": "saltutil.sync_all:",
 		"body": [

--- a/snippets/schedule.json
+++ b/snippets/schedule.json
@@ -1,13 +1,4 @@
 {
-	"schedule state": {
-		"prefix": [
-			"schedule."
-		],
-		"body": [
-			"schedule.${1|absent,disabled,enabled,present|}:"
-		],
-		"description": "schedule state"
-	},
 	"schedule.absent": {
 		"prefix": "schedule.absent:",
 		"body": [

--- a/snippets/schedule.json
+++ b/snippets/schedule.json
@@ -1,0 +1,43 @@
+{
+	"schedule state": {
+		"prefix": [
+			"schedule."
+		],
+		"body": [
+			"schedule.${1|absent,disabled,enabled,present|}:"
+		],
+		"description": "schedule state"
+	},
+	"schedule.absent": {
+		"prefix": "schedule.absent:",
+		"body": [
+			"schedule.absent:",
+			"$0"
+		],
+		"description": "schedule.absent:"
+	},
+	"schedule.disabled": {
+		"prefix": "schedule.disabled:",
+		"body": [
+			"schedule.disabled:",
+			"$0"
+		],
+		"description": "schedule.disabled:"
+	},
+	"schedule.enabled": {
+		"prefix": "schedule.enabled:",
+		"body": [
+			"schedule.enabled:",
+			"$0"
+		],
+		"description": "schedule.enabled:"
+	},
+	"schedule.present": {
+		"prefix": "schedule.present:",
+		"body": [
+			"schedule.present:",
+			"$0"
+		],
+		"description": "schedule.present:"
+	}
+}

--- a/snippets/serverdensity_device.json
+++ b/snippets/serverdensity_device.json
@@ -1,13 +1,4 @@
 {
-	"serverdensity_device state": {
-		"prefix": [
-			"serverdensity_device."
-		],
-		"body": [
-			"serverdensity_device.${1|monitored|}:"
-		],
-		"description": "serverdensity_device state"
-	},
 	"serverdensity_device.monitored": {
 		"prefix": "serverdensity_device.monitored:",
 		"body": [

--- a/snippets/serverdensity_device.json
+++ b/snippets/serverdensity_device.json
@@ -1,0 +1,19 @@
+{
+	"serverdensity_device state": {
+		"prefix": [
+			"serverdensity_device."
+		],
+		"body": [
+			"serverdensity_device.${1|monitored|}:"
+		],
+		"description": "serverdensity_device state"
+	},
+	"serverdensity_device.monitored": {
+		"prefix": "serverdensity_device.monitored:",
+		"body": [
+			"serverdensity_device.monitored:",
+			"$0"
+		],
+		"description": "serverdensity_device.monitored:"
+	}
+}

--- a/snippets/service.json
+++ b/snippets/service.json
@@ -1,0 +1,50 @@
+{
+	"service.dead": {
+		"body": [
+			"service.dead:",
+			"$0"
+		],
+		"prefix": "service.dead:",
+		"description": "service.dead:"
+	},
+	"service.running": {
+		"body": [
+			"service.running:",
+			"$0"
+		],
+		"prefix": "service.running:",
+		"description": "service.running:"
+	},
+	"service.disabled": {
+		"body": [
+			"service.disabled:",
+			"$0"
+		],
+		"prefix": "service.disabled:",
+		"description": "service.disabled:"
+	},
+	"service.unmasked": {
+		"body": [
+			"service.unmasked:",
+			"$0"
+		],
+		"prefix": "service.unmasked:",
+		"description": "service.unmasked:"
+	},
+	"service.enabled": {
+		"body": [
+			"service.enabled:",
+			"$0"
+		],
+		"prefix": "service.enabled:",
+		"description": "service.enabled:"
+	},
+	"service.masked": {
+		"body": [
+			"service.masked:",
+			"$0"
+		],
+		"prefix": "service.masked:",
+		"description": "service.masked:"
+	}
+}

--- a/snippets/slack.json
+++ b/snippets/slack.json
@@ -1,13 +1,4 @@
 {
-	"slack state": {
-		"prefix": [
-			"slack."
-		],
-		"body": [
-			"slack.${1|post_message|}:"
-		],
-		"description": "slack state"
-	},
 	"slack.post_message": {
 		"prefix": "slack.post_message:",
 		"body": [

--- a/snippets/slack.json
+++ b/snippets/slack.json
@@ -1,0 +1,19 @@
+{
+	"slack state": {
+		"prefix": [
+			"slack."
+		],
+		"body": [
+			"slack.${1|post_message|}:"
+		],
+		"description": "slack state"
+	},
+	"slack.post_message": {
+		"prefix": "slack.post_message:",
+		"body": [
+			"slack.post_message:",
+			"$0"
+		],
+		"description": "slack.post_message:"
+	}
+}

--- a/snippets/smtp.json
+++ b/snippets/smtp.json
@@ -1,0 +1,19 @@
+{
+	"smtp state": {
+		"prefix": [
+			"smtp."
+		],
+		"body": [
+			"smtp.${1|send_msg|}:"
+		],
+		"description": "smtp state"
+	},
+	"smtp.send_msg": {
+		"prefix": "smtp.send_msg:",
+		"body": [
+			"smtp.send_msg:",
+			"$0"
+		],
+		"description": "smtp.send_msg:"
+	}
+}

--- a/snippets/smtp.json
+++ b/snippets/smtp.json
@@ -1,13 +1,4 @@
 {
-	"smtp state": {
-		"prefix": [
-			"smtp."
-		],
-		"body": [
-			"smtp.${1|send_msg|}:"
-		],
-		"description": "smtp state"
-	},
 	"smtp.send_msg": {
 		"prefix": "smtp.send_msg:",
 		"body": [

--- a/snippets/solrcloud.json
+++ b/snippets/solrcloud.json
@@ -1,13 +1,4 @@
 {
-	"solrcloud state": {
-		"prefix": [
-			"solrcloud."
-		],
-		"body": [
-			"solrcloud.${1|alias,collection|}:"
-		],
-		"description": "solrcloud state"
-	},
 	"solrcloud.alias": {
 		"prefix": "solrcloud.alias:",
 		"body": [

--- a/snippets/solrcloud.json
+++ b/snippets/solrcloud.json
@@ -1,0 +1,27 @@
+{
+	"solrcloud state": {
+		"prefix": [
+			"solrcloud."
+		],
+		"body": [
+			"solrcloud.${1|alias,collection|}:"
+		],
+		"description": "solrcloud state"
+	},
+	"solrcloud.alias": {
+		"prefix": "solrcloud.alias:",
+		"body": [
+			"solrcloud.alias:",
+			"$0"
+		],
+		"description": "solrcloud.alias:"
+	},
+	"solrcloud.collection": {
+		"prefix": "solrcloud.collection:",
+		"body": [
+			"solrcloud.collection:",
+			"$0"
+		],
+		"description": "solrcloud.collection:"
+	}
+}

--- a/snippets/sqlite3.json
+++ b/snippets/sqlite3.json
@@ -1,13 +1,4 @@
 {
-	"sqlite3 state": {
-		"prefix": [
-			"sqlite3."
-		],
-		"body": [
-			"sqlite3.${1|row_absent,row_present,table_absent,table_present|}:"
-		],
-		"description": "sqlite3 state"
-	},
 	"sqlite3.row_absent": {
 		"prefix": "sqlite3.row_absent:",
 		"body": [

--- a/snippets/sqlite3.json
+++ b/snippets/sqlite3.json
@@ -1,0 +1,43 @@
+{
+	"sqlite3 state": {
+		"prefix": [
+			"sqlite3."
+		],
+		"body": [
+			"sqlite3.${1|row_absent,row_present,table_absent,table_present|}:"
+		],
+		"description": "sqlite3 state"
+	},
+	"sqlite3.row_absent": {
+		"prefix": "sqlite3.row_absent:",
+		"body": [
+			"sqlite3.row_absent:",
+			"$0"
+		],
+		"description": "sqlite3.row_absent:"
+	},
+	"sqlite3.row_present": {
+		"prefix": "sqlite3.row_present:",
+		"body": [
+			"sqlite3.row_present:",
+			"$0"
+		],
+		"description": "sqlite3.row_present:"
+	},
+	"sqlite3.table_absent": {
+		"prefix": "sqlite3.table_absent:",
+		"body": [
+			"sqlite3.table_absent:",
+			"$0"
+		],
+		"description": "sqlite3.table_absent:"
+	},
+	"sqlite3.table_present": {
+		"prefix": "sqlite3.table_present:",
+		"body": [
+			"sqlite3.table_present:",
+			"$0"
+		],
+		"description": "sqlite3.table_present:"
+	}
+}

--- a/snippets/ssh_auth.json
+++ b/snippets/ssh_auth.json
@@ -1,13 +1,4 @@
 {
-	"ssh_auth state": {
-		"prefix": [
-			"ssh_auth."
-		],
-		"body": [
-			"ssh_auth.${1|absent,manage,present|}:"
-		],
-		"description": "ssh_auth state"
-	},
 	"ssh_auth.absent": {
 		"prefix": "ssh_auth.absent:",
 		"body": [

--- a/snippets/ssh_auth.json
+++ b/snippets/ssh_auth.json
@@ -1,0 +1,35 @@
+{
+	"ssh_auth state": {
+		"prefix": [
+			"ssh_auth."
+		],
+		"body": [
+			"ssh_auth.${1|absent,manage,present|}:"
+		],
+		"description": "ssh_auth state"
+	},
+	"ssh_auth.absent": {
+		"prefix": "ssh_auth.absent:",
+		"body": [
+			"ssh_auth.absent:",
+			"$0"
+		],
+		"description": "ssh_auth.absent:"
+	},
+	"ssh_auth.manage": {
+		"prefix": "ssh_auth.manage:",
+		"body": [
+			"ssh_auth.manage:",
+			"$0"
+		],
+		"description": "ssh_auth.manage:"
+	},
+	"ssh_auth.present": {
+		"prefix": "ssh_auth.present:",
+		"body": [
+			"ssh_auth.present:",
+			"$0"
+		],
+		"description": "ssh_auth.present:"
+	}
+}

--- a/snippets/ssh_known_hosts.json
+++ b/snippets/ssh_known_hosts.json
@@ -1,0 +1,27 @@
+{
+	"ssh_known_hosts state": {
+		"prefix": [
+			"ssh_known_hosts."
+		],
+		"body": [
+			"ssh_known_hosts.${1|absent,present|}:"
+		],
+		"description": "ssh_known_hosts state"
+	},
+	"ssh_known_hosts.absent": {
+		"prefix": "ssh_known_hosts.absent:",
+		"body": [
+			"ssh_known_hosts.absent:",
+			"$0"
+		],
+		"description": "ssh_known_hosts.absent:"
+	},
+	"ssh_known_hosts.present": {
+		"prefix": "ssh_known_hosts.present:",
+		"body": [
+			"ssh_known_hosts.present:",
+			"$0"
+		],
+		"description": "ssh_known_hosts.present:"
+	}
+}

--- a/snippets/ssh_known_hosts.json
+++ b/snippets/ssh_known_hosts.json
@@ -1,13 +1,4 @@
 {
-	"ssh_known_hosts state": {
-		"prefix": [
-			"ssh_known_hosts."
-		],
-		"body": [
-			"ssh_known_hosts.${1|absent,present|}:"
-		],
-		"description": "ssh_known_hosts state"
-	},
 	"ssh_known_hosts.absent": {
 		"prefix": "ssh_known_hosts.absent:",
 		"body": [

--- a/snippets/stateconf.json
+++ b/snippets/stateconf.json
@@ -1,13 +1,4 @@
 {
-	"stateconf state": {
-		"prefix": [
-			"stateconf."
-		],
-		"body": [
-			"stateconf.${1|context,set|}:"
-		],
-		"description": "stateconf state"
-	},
 	"stateconf.context": {
 		"prefix": "stateconf.context:",
 		"body": [

--- a/snippets/stateconf.json
+++ b/snippets/stateconf.json
@@ -1,0 +1,27 @@
+{
+	"stateconf state": {
+		"prefix": [
+			"stateconf."
+		],
+		"body": [
+			"stateconf.${1|context,set|}:"
+		],
+		"description": "stateconf state"
+	},
+	"stateconf.context": {
+		"prefix": "stateconf.context:",
+		"body": [
+			"stateconf.context:",
+			"$0"
+		],
+		"description": "stateconf.context:"
+	},
+	"stateconf.set": {
+		"prefix": "stateconf.set:",
+		"body": [
+			"stateconf.set:",
+			"$0"
+		],
+		"description": "stateconf.set:"
+	}
+}

--- a/snippets/status.json
+++ b/snippets/status.json
@@ -1,13 +1,4 @@
 {
-	"status state": {
-		"prefix": [
-			"status."
-		],
-		"body": [
-			"status.${1|loadavg,process|}:"
-		],
-		"description": "status state"
-	},
 	"status.loadavg": {
 		"prefix": "status.loadavg:",
 		"body": [

--- a/snippets/status.json
+++ b/snippets/status.json
@@ -1,0 +1,27 @@
+{
+	"status state": {
+		"prefix": [
+			"status."
+		],
+		"body": [
+			"status.${1|loadavg,process|}:"
+		],
+		"description": "status state"
+	},
+	"status.loadavg": {
+		"prefix": "status.loadavg:",
+		"body": [
+			"status.loadavg:",
+			"$0"
+		],
+		"description": "status.loadavg:"
+	},
+	"status.process": {
+		"prefix": "status.process:",
+		"body": [
+			"status.process:",
+			"$0"
+		],
+		"description": "status.process:"
+	}
+}

--- a/snippets/statuspage.json
+++ b/snippets/statuspage.json
@@ -1,13 +1,4 @@
 {
-	"statuspage state": {
-		"prefix": [
-			"statuspage."
-		],
-		"body": [
-			"statuspage.${1|create,delete,managed,update|}:"
-		],
-		"description": "statuspage state"
-	},
 	"statuspage.create": {
 		"prefix": "statuspage.create:",
 		"body": [

--- a/snippets/statuspage.json
+++ b/snippets/statuspage.json
@@ -1,0 +1,43 @@
+{
+	"statuspage state": {
+		"prefix": [
+			"statuspage."
+		],
+		"body": [
+			"statuspage.${1|create,delete,managed,update|}:"
+		],
+		"description": "statuspage state"
+	},
+	"statuspage.create": {
+		"prefix": "statuspage.create:",
+		"body": [
+			"statuspage.create:",
+			"$0"
+		],
+		"description": "statuspage.create:"
+	},
+	"statuspage.delete": {
+		"prefix": "statuspage.delete:",
+		"body": [
+			"statuspage.delete:",
+			"$0"
+		],
+		"description": "statuspage.delete:"
+	},
+	"statuspage.managed": {
+		"prefix": "statuspage.managed:",
+		"body": [
+			"statuspage.managed:",
+			"$0"
+		],
+		"description": "statuspage.managed:"
+	},
+	"statuspage.update": {
+		"prefix": "statuspage.update:",
+		"body": [
+			"statuspage.update:",
+			"$0"
+		],
+		"description": "statuspage.update:"
+	}
+}

--- a/snippets/supervisord.json
+++ b/snippets/supervisord.json
@@ -1,0 +1,27 @@
+{
+	"supervisord state": {
+		"prefix": [
+			"supervisord."
+		],
+		"body": [
+			"supervisord.${1|dead,running|}:"
+		],
+		"description": "supervisord state"
+	},
+	"supervisord.dead": {
+		"prefix": "supervisord.dead:",
+		"body": [
+			"supervisord.dead:",
+			"$0"
+		],
+		"description": "supervisord.dead:"
+	},
+	"supervisord.running": {
+		"prefix": "supervisord.running:",
+		"body": [
+			"supervisord.running:",
+			"$0"
+		],
+		"description": "supervisord.running:"
+	}
+}

--- a/snippets/supervisord.json
+++ b/snippets/supervisord.json
@@ -1,13 +1,4 @@
 {
-	"supervisord state": {
-		"prefix": [
-			"supervisord."
-		],
-		"body": [
-			"supervisord.${1|dead,running|}:"
-		],
-		"description": "supervisord state"
-	},
 	"supervisord.dead": {
 		"prefix": "supervisord.dead:",
 		"body": [

--- a/snippets/syslog_ng.json
+++ b/snippets/syslog_ng.json
@@ -1,13 +1,4 @@
 {
-	"syslog_ng state": {
-		"prefix": [
-			"syslog_ng."
-		],
-		"body": [
-			"syslog_ng.${1|config,reloaded,started,stopped|}:"
-		],
-		"description": "syslog_ng state"
-	},
 	"syslog_ng.config": {
 		"prefix": "syslog_ng.config:",
 		"body": [

--- a/snippets/syslog_ng.json
+++ b/snippets/syslog_ng.json
@@ -1,0 +1,43 @@
+{
+	"syslog_ng state": {
+		"prefix": [
+			"syslog_ng."
+		],
+		"body": [
+			"syslog_ng.${1|config,reloaded,started,stopped|}:"
+		],
+		"description": "syslog_ng state"
+	},
+	"syslog_ng.config": {
+		"prefix": "syslog_ng.config:",
+		"body": [
+			"syslog_ng.config:",
+			"$0"
+		],
+		"description": "syslog_ng.config:"
+	},
+	"syslog_ng.reloaded": {
+		"prefix": "syslog_ng.reloaded:",
+		"body": [
+			"syslog_ng.reloaded:",
+			"$0"
+		],
+		"description": "syslog_ng.reloaded:"
+	},
+	"syslog_ng.started": {
+		"prefix": "syslog_ng.started:",
+		"body": [
+			"syslog_ng.started:",
+			"$0"
+		],
+		"description": "syslog_ng.started:"
+	},
+	"syslog_ng.stopped": {
+		"prefix": "syslog_ng.stopped:",
+		"body": [
+			"syslog_ng.stopped:",
+			"$0"
+		],
+		"description": "syslog_ng.stopped:"
+	}
+}

--- a/snippets/system.json
+++ b/snippets/system.json
@@ -1,0 +1,58 @@
+{
+	"system.computer_name": {
+		"body": [
+			"system.computer_name:",
+			"$0"
+		],
+		"prefix": "system.computer_name:",
+		"description": "system.computer_name:"
+	},
+	"system.shutdown": {
+		"body": [
+			"system.shutdown:",
+			"$0"
+		],
+		"prefix": "system.shutdown:",
+		"description": "system.shutdown:"
+	},
+	"system.computer_desc": {
+		"body": [
+			"system.computer_desc:",
+			"$0"
+		],
+		"prefix": "system.computer_desc:",
+		"description": "system.computer_desc:"
+	},
+	"system.computer_description": {
+		"body": [
+			"system.computer_description:",
+			"$0"
+		],
+		"prefix": "system.computer_description:",
+		"description": "system.computer_description:"
+	},
+	"system.join_domain": {
+		"body": [
+			"system.join_domain:",
+			"$0"
+		],
+		"prefix": "system.join_domain:",
+		"description": "system.join_domain:"
+	},
+	"system.hostname": {
+		"body": [
+			"system.hostname:",
+			"$0"
+		],
+		"prefix": "system.hostname:",
+		"description": "system.hostname:"
+	},
+	"system.reboot": {
+		"body": [
+			"system.reboot:",
+			"$0"
+		],
+		"prefix": "system.reboot:",
+		"description": "system.reboot:"
+	}
+}

--- a/snippets/telemetry_alert.json
+++ b/snippets/telemetry_alert.json
@@ -1,13 +1,4 @@
 {
-	"telemetry_alert state": {
-		"prefix": [
-			"telemetry_alert."
-		],
-		"body": [
-			"telemetry_alert.${1|absent,present|}:"
-		],
-		"description": "telemetry_alert state"
-	},
 	"telemetry_alert.absent": {
 		"prefix": "telemetry_alert.absent:",
 		"body": [

--- a/snippets/telemetry_alert.json
+++ b/snippets/telemetry_alert.json
@@ -1,0 +1,27 @@
+{
+	"telemetry_alert state": {
+		"prefix": [
+			"telemetry_alert."
+		],
+		"body": [
+			"telemetry_alert.${1|absent,present|}:"
+		],
+		"description": "telemetry_alert state"
+	},
+	"telemetry_alert.absent": {
+		"prefix": "telemetry_alert.absent:",
+		"body": [
+			"telemetry_alert.absent:",
+			"$0"
+		],
+		"description": "telemetry_alert.absent:"
+	},
+	"telemetry_alert.present": {
+		"prefix": "telemetry_alert.present:",
+		"body": [
+			"telemetry_alert.present:",
+			"$0"
+		],
+		"description": "telemetry_alert.present:"
+	}
+}

--- a/snippets/test.json
+++ b/snippets/test.json
@@ -1,13 +1,4 @@
 {
-	"test state": {
-		"prefix": [
-			"test."
-		],
-		"body": [
-			"test.${1|check_pillar,configurable_test_state,fail_with_changes,fail_without_changes,nop,show_notification,succeed_with_changes,succeed_without_changes|}:"
-		],
-		"description": "test state"
-	},
 	"test.check_pillar": {
 		"prefix": [
 			"test.check_pillar:"

--- a/snippets/test.json
+++ b/snippets/test.json
@@ -1,0 +1,60 @@
+{
+	"test state": {
+		"prefix": ["test."],
+		"body": ["test.${1|check_pillar,configurable_test_state,fail_with_changes,fail_without_changes,nop,show_notification,succeed_with_changes,succeed_without_changes|}:"],
+		"description": "test state"
+	  },
+	  "test.check_pillar": {
+		"prefix": ["test.check_pillar:"],
+		"body": ["test.check_pillar:",
+			"\t- present:",
+			"\t\t- ${1:unique_string}",
+			"$0"
+		],
+		"description": "test.check_pillar"
+	  },
+	  "test.configurable_test_state": {
+		"prefix": ["test.configurable_test_state:"],
+		"body": ["test.configurable_test_state:",
+			"\t- name: ${1:unique_string}",
+			"\t- changes: True",
+			"\t- result: True",
+			"\t- comment: ''",
+			"$0"
+		],
+		"description": "test.check_pillar"
+	  },
+	  "test.fail_with_changes": {
+		"prefix": "test.fail_with_changes:",
+		"body": ["test.fail_with_changes:",
+			"\t- name: ${1:unique_string}",
+			"$0"
+		],
+		"description": "test.fail_with_changes"
+	  },
+	  "test.fail_without_changes": {
+		"prefix": "test.fail_without_changes:",
+		"body": ["test.fail_without_changes:",
+			"\t- name: ${1:unique_string}",
+			"$0"
+		],
+		"description": "test.fail_without_changes"
+	  },
+	  "test.nop": {
+		"prefix": "test.nop:",
+		"body": ["test.nop:",
+			"\t- name: ${1:unique_string}",
+			"$0"
+		],
+		"description": "test.nop"
+	  },
+	  "test.show_notification": {
+		"prefix": "test.show_notification:",
+		"body": ["test.show_notification:",
+			"\t- name: ${1:unique_string}",
+			"\t- text: \"${2:text_returned_in_comment}\"",
+			"$0"
+		],
+		"description": "test.show_notification"
+	  }
+}

--- a/snippets/test.json
+++ b/snippets/test.json
@@ -1,21 +1,31 @@
 {
 	"test state": {
-		"prefix": ["test."],
-		"body": ["test.${1|check_pillar,configurable_test_state,fail_with_changes,fail_without_changes,nop,show_notification,succeed_with_changes,succeed_without_changes|}:"],
+		"prefix": [
+			"test."
+		],
+		"body": [
+			"test.${1|check_pillar,configurable_test_state,fail_with_changes,fail_without_changes,nop,show_notification,succeed_with_changes,succeed_without_changes|}:"
+		],
 		"description": "test state"
-	  },
-	  "test.check_pillar": {
-		"prefix": ["test.check_pillar:"],
-		"body": ["test.check_pillar:",
+	},
+	"test.check_pillar": {
+		"prefix": [
+			"test.check_pillar:"
+		],
+		"body": [
+			"test.check_pillar:",
 			"\t- present:",
 			"\t\t- ${1:unique_string}",
 			"$0"
 		],
 		"description": "test.check_pillar"
-	  },
-	  "test.configurable_test_state": {
-		"prefix": ["test.configurable_test_state:"],
-		"body": ["test.configurable_test_state:",
+	},
+	"test.configurable_test_state": {
+		"prefix": [
+			"test.configurable_test_state:"
+		],
+		"body": [
+			"test.configurable_test_state:",
 			"\t- name: ${1:unique_string}",
 			"\t- changes: True",
 			"\t- result: True",
@@ -23,38 +33,60 @@
 			"$0"
 		],
 		"description": "test.check_pillar"
-	  },
-	  "test.fail_with_changes": {
+	},
+	"test.fail_with_changes": {
 		"prefix": "test.fail_with_changes:",
-		"body": ["test.fail_with_changes:",
+		"body": [
+			"test.fail_with_changes:",
 			"\t- name: ${1:unique_string}",
 			"$0"
 		],
 		"description": "test.fail_with_changes"
-	  },
-	  "test.fail_without_changes": {
+	},
+	"test.fail_without_changes": {
 		"prefix": "test.fail_without_changes:",
-		"body": ["test.fail_without_changes:",
+		"body": [
+			"test.fail_without_changes:",
 			"\t- name: ${1:unique_string}",
 			"$0"
 		],
 		"description": "test.fail_without_changes"
-	  },
-	  "test.nop": {
+	},
+	"test.nop": {
 		"prefix": "test.nop:",
-		"body": ["test.nop:",
+		"body": [
+			"test.nop:",
 			"\t- name: ${1:unique_string}",
 			"$0"
 		],
 		"description": "test.nop"
-	  },
-	  "test.show_notification": {
+	},
+	"test.show_notification": {
 		"prefix": "test.show_notification:",
-		"body": ["test.show_notification:",
+		"body": [
+			"test.show_notification:",
 			"\t- name: ${1:unique_string}",
 			"\t- text: \"${2:text_returned_in_comment}\"",
 			"$0"
 		],
 		"description": "test.show_notification"
-	  }
+	},
+	"test.succeed_with_changes": {
+		"prefix": "test.succeed_with_changes:",
+		"body": [
+            "test.succeed_with_changes:",
+            "\t- name: ${1:unique_string}",
+			"$0"
+		],
+		"description": "test.succeed_with_changes:"
+	},
+	"test.succeed_without_changes": {
+		"prefix": "test.succeed_without_changes:",
+		"body": [
+            "test.succeed_without_changes:",
+            "\t- name: ${1:unique_string}",
+			"$0"
+		],
+		"description": "test.succeed_without_changes:"
+	}
 }

--- a/snippets/timezone.json
+++ b/snippets/timezone.json
@@ -1,13 +1,4 @@
 {
-	"timezone state": {
-		"prefix": [
-			"timezone."
-		],
-		"body": [
-			"timezone.${1|system|}:"
-		],
-		"description": "timezone state"
-	},
 	"timezone.system": {
 		"prefix": "timezone.system:",
 		"body": [

--- a/snippets/timezone.json
+++ b/snippets/timezone.json
@@ -1,0 +1,19 @@
+{
+	"timezone state": {
+		"prefix": [
+			"timezone."
+		],
+		"body": [
+			"timezone.${1|system|}:"
+		],
+		"description": "timezone state"
+	},
+	"timezone.system": {
+		"prefix": "timezone.system:",
+		"body": [
+			"timezone.system:",
+			"$0"
+		],
+		"description": "timezone.system:"
+	}
+}

--- a/snippets/tls.json
+++ b/snippets/tls.json
@@ -1,0 +1,10 @@
+{
+	"tls.valid_certificate": {
+		"body": [
+			"tls.valid_certificate:",
+			"$0"
+		],
+		"prefix": "tls.valid_certificate:",
+		"description": "tls.valid_certificate:"
+	}
+}

--- a/snippets/tomcat.json
+++ b/snippets/tomcat.json
@@ -1,0 +1,26 @@
+{
+	"tomcat.undeployed": {
+		"prefix": "tomcat.undeployed:",
+		"body": [
+			"tomcat.undeployed:",
+			"$0"
+		],
+		"description": "tomcat.undeployed:"
+	},
+	"tomcat.wait": {
+		"prefix": "tomcat.wait:",
+		"body": [
+			"tomcat.wait:",
+			"$0"
+		],
+		"description": "tomcat.wait:"
+	},
+	"tomcat.war_deployed": {
+		"prefix": "tomcat.war_deployed:",
+		"body": [
+			"tomcat.war_deployed:",
+			"$0"
+		],
+		"description": "tomcat.war_deployed:"
+	}
+}

--- a/snippets/tuned.json
+++ b/snippets/tuned.json
@@ -1,0 +1,27 @@
+{
+	"tuned state": {
+		"prefix": [
+			"tuned."
+		],
+		"body": [
+			"tuned.${1|off,profile|}:"
+		],
+		"description": "tuned state"
+	},
+	"tuned.off": {
+		"prefix": "tuned.off:",
+		"body": [
+			"tuned.off:",
+			"$0"
+		],
+		"description": "tuned.off:"
+	},
+	"tuned.profile": {
+		"prefix": "tuned.profile:",
+		"body": [
+			"tuned.profile:",
+			"$0"
+		],
+		"description": "tuned.profile:"
+	}
+}

--- a/snippets/tuned.json
+++ b/snippets/tuned.json
@@ -1,13 +1,4 @@
 {
-	"tuned state": {
-		"prefix": [
-			"tuned."
-		],
-		"body": [
-			"tuned.${1|off,profile|}:"
-		],
-		"description": "tuned state"
-	},
 	"tuned.off": {
 		"prefix": "tuned.off:",
 		"body": [

--- a/snippets/uptime.json
+++ b/snippets/uptime.json
@@ -1,0 +1,19 @@
+{
+	"uptime state": {
+		"prefix": [
+			"uptime."
+		],
+		"body": [
+			"uptime.${1|monitored|}:"
+		],
+		"description": "uptime state"
+	},
+	"uptime.monitored": {
+		"prefix": "uptime.monitored:",
+		"body": [
+			"uptime.monitored:",
+			"$0"
+		],
+		"description": "uptime.monitored:"
+	}
+}

--- a/snippets/uptime.json
+++ b/snippets/uptime.json
@@ -1,13 +1,4 @@
 {
-	"uptime state": {
-		"prefix": [
-			"uptime."
-		],
-		"body": [
-			"uptime.${1|monitored|}:"
-		],
-		"description": "uptime state"
-	},
 	"uptime.monitored": {
 		"prefix": "uptime.monitored:",
 		"body": [

--- a/snippets/user.json
+++ b/snippets/user.json
@@ -1,13 +1,4 @@
 {
-	"user state": {
-		"prefix": [
-			"user."
-		],
-		"body": [
-			"user.${1|absent,iteritems,present|}:"
-		],
-		"description": "user state"
-	},
 	"user.absent": {
 		"prefix": "user.absent:",
 		"body": [

--- a/snippets/user.json
+++ b/snippets/user.json
@@ -1,0 +1,35 @@
+{
+	"user state": {
+		"prefix": [
+			"user."
+		],
+		"body": [
+			"user.${1|absent,iteritems,present|}:"
+		],
+		"description": "user state"
+	},
+	"user.absent": {
+		"prefix": "user.absent:",
+		"body": [
+			"user.absent:",
+			"$0"
+		],
+		"description": "user.absent:"
+	},
+	"user.iteritems": {
+		"prefix": "user.iteritems:",
+		"body": [
+			"user.iteritems:",
+			"$0"
+		],
+		"description": "user.iteritems:"
+	},
+	"user.present": {
+		"prefix": "user.present:",
+		"body": [
+			"user.present:",
+			"$0"
+		],
+		"description": "user.present:"
+	}
+}

--- a/snippets/vagrant.json
+++ b/snippets/vagrant.json
@@ -1,0 +1,58 @@
+{
+	"vagrant.running": {
+		"body": [
+			"vagrant.running:",
+			"$0"
+		],
+		"prefix": "vagrant.running:",
+		"description": "vagrant.running:"
+	},
+	"vagrant.rebooted": {
+		"body": [
+			"vagrant.rebooted:",
+			"$0"
+		],
+		"prefix": "vagrant.rebooted:",
+		"description": "vagrant.rebooted:"
+	},
+	"vagrant.stopped": {
+		"body": [
+			"vagrant.stopped:",
+			"$0"
+		],
+		"prefix": "vagrant.stopped:",
+		"description": "vagrant.stopped:"
+	},
+	"vagrant.paused": {
+		"body": [
+			"vagrant.paused:",
+			"$0"
+		],
+		"prefix": "vagrant.paused:",
+		"description": "vagrant.paused:"
+	},
+	"vagrant.powered_off": {
+		"body": [
+			"vagrant.powered_off:",
+			"$0"
+		],
+		"prefix": "vagrant.powered_off:",
+		"description": "vagrant.powered_off:"
+	},
+	"vagrant.destroyed": {
+		"body": [
+			"vagrant.destroyed:",
+			"$0"
+		],
+		"prefix": "vagrant.destroyed:",
+		"description": "vagrant.destroyed:"
+	},
+	"vagrant.initialized": {
+		"body": [
+			"vagrant.initialized:",
+			"$0"
+		],
+		"prefix": "vagrant.initialized:",
+		"description": "vagrant.initialized:"
+	}
+}

--- a/snippets/vault.json
+++ b/snippets/vault.json
@@ -1,0 +1,19 @@
+{
+	"vault state": {
+		"prefix": [
+			"vault."
+		],
+		"body": [
+			"vault.${1|policy_present|}:"
+		],
+		"description": "vault state"
+	},
+	"vault.policy_present": {
+		"prefix": "vault.policy_present:",
+		"body": [
+			"vault.policy_present:",
+			"$0"
+		],
+		"description": "vault.policy_present:"
+	}
+}

--- a/snippets/vault.json
+++ b/snippets/vault.json
@@ -1,13 +1,4 @@
 {
-	"vault state": {
-		"prefix": [
-			"vault."
-		],
-		"body": [
-			"vault.${1|policy_present|}:"
-		],
-		"description": "vault state"
-	},
 	"vault.policy_present": {
 		"prefix": "vault.policy_present:",
 		"body": [

--- a/snippets/vbox_guest.json
+++ b/snippets/vbox_guest.json
@@ -1,13 +1,4 @@
 {
-	"vbox_guest state": {
-		"prefix": [
-			"vbox_guest."
-		],
-		"body": [
-			"vbox_guest.${1|additions_installed,additions_removed,grant_access_to_shared_folders_to|}:"
-		],
-		"description": "vbox_guest state"
-	},
 	"vbox_guest.additions_installed": {
 		"prefix": "vbox_guest.additions_installed:",
 		"body": [

--- a/snippets/vbox_guest.json
+++ b/snippets/vbox_guest.json
@@ -1,0 +1,35 @@
+{
+	"vbox_guest state": {
+		"prefix": [
+			"vbox_guest."
+		],
+		"body": [
+			"vbox_guest.${1|additions_installed,additions_removed,grant_access_to_shared_folders_to|}:"
+		],
+		"description": "vbox_guest state"
+	},
+	"vbox_guest.additions_installed": {
+		"prefix": "vbox_guest.additions_installed:",
+		"body": [
+			"vbox_guest.additions_installed:",
+			"$0"
+		],
+		"description": "vbox_guest.additions_installed:"
+	},
+	"vbox_guest.additions_removed": {
+		"prefix": "vbox_guest.additions_removed:",
+		"body": [
+			"vbox_guest.additions_removed:",
+			"$0"
+		],
+		"description": "vbox_guest.additions_removed:"
+	},
+	"vbox_guest.grant_access_to_shared_folders_to": {
+		"prefix": "vbox_guest.grant_access_to_shared_folders_to:",
+		"body": [
+			"vbox_guest.grant_access_to_shared_folders_to:",
+			"$0"
+		],
+		"description": "vbox_guest.grant_access_to_shared_folders_to:"
+	}
+}

--- a/snippets/virtualenv.json
+++ b/snippets/virtualenv.json
@@ -1,0 +1,27 @@
+{
+	"virtualenv state": {
+		"prefix": [
+			"virtualenv."
+		],
+		"body": [
+			"virtualenv.${1|manage,managed|}:"
+		],
+		"description": "virtualenv state"
+	},
+	"virtualenv.manage": {
+		"prefix": "virtualenv.manage:",
+		"body": [
+			"virtualenv.manage:",
+			"$0"
+		],
+		"description": "virtualenv.manage:"
+	},
+	"virtualenv.managed": {
+		"prefix": "virtualenv.managed:",
+		"body": [
+			"virtualenv.managed:",
+			"$0"
+		],
+		"description": "virtualenv.managed:"
+	}
+}

--- a/snippets/virtualenv.json
+++ b/snippets/virtualenv.json
@@ -1,13 +1,4 @@
 {
-	"virtualenv state": {
-		"prefix": [
-			"virtualenv."
-		],
-		"body": [
-			"virtualenv.${1|manage,managed|}:"
-		],
-		"description": "virtualenv state"
-	},
 	"virtualenv.manage": {
 		"prefix": "virtualenv.manage:",
 		"body": [

--- a/snippets/win_dacl.json
+++ b/snippets/win_dacl.json
@@ -1,0 +1,34 @@
+{
+	"win_dacl.present": {
+		"body": [
+			"win_dacl.present:",
+			"$0"
+		],
+		"prefix": "win_dacl.present:",
+		"description": "win_dacl.present:"
+	},
+	"win_dacl.disinherit": {
+		"body": [
+			"win_dacl.disinherit:",
+			"$0"
+		],
+		"prefix": "win_dacl.disinherit:",
+		"description": "win_dacl.disinherit:"
+	},
+	"win_dacl.absent": {
+		"body": [
+			"win_dacl.absent:",
+			"$0"
+		],
+		"prefix": "win_dacl.absent:",
+		"description": "win_dacl.absent:"
+	},
+	"win_dacl.inherit": {
+		"body": [
+			"win_dacl.inherit:",
+			"$0"
+		],
+		"prefix": "win_dacl.inherit:",
+		"description": "win_dacl.inherit:"
+	}
+}

--- a/snippets/win_dns_client.json
+++ b/snippets/win_dns_client.json
@@ -1,0 +1,26 @@
+{
+	"win_dns_client.dns_dhcp": {
+		"body": [
+			"win_dns_client.dns_dhcp:",
+			"$0"
+		],
+		"prefix": "win_dns_client.dns_dhcp:",
+		"description": "win_dns_client.dns_dhcp:"
+	},
+	"win_dns_client.dns_exists": {
+		"body": [
+			"win_dns_client.dns_exists:",
+			"$0"
+		],
+		"prefix": "win_dns_client.dns_exists:",
+		"description": "win_dns_client.dns_exists:"
+	},
+	"win_dns_client.primary_suffix": {
+		"body": [
+			"win_dns_client.primary_suffix:",
+			"$0"
+		],
+		"prefix": "win_dns_client.primary_suffix:",
+		"description": "win_dns_client.primary_suffix:"
+	}
+}

--- a/snippets/win_firewall.json
+++ b/snippets/win_firewall.json
@@ -1,0 +1,26 @@
+{
+	"win_firewall.add_rule": {
+		"body": [
+			"win_firewall.add_rule:",
+			"$0"
+		],
+		"prefix": "win_firewall.add_rule:",
+		"description": "win_firewall.add_rule:"
+	},
+	"win_firewall.enabled": {
+		"body": [
+			"win_firewall.enabled:",
+			"$0"
+		],
+		"prefix": "win_firewall.enabled:",
+		"description": "win_firewall.enabled:"
+	},
+	"win_firewall.disabled": {
+		"body": [
+			"win_firewall.disabled:",
+			"$0"
+		],
+		"prefix": "win_firewall.disabled:",
+		"description": "win_firewall.disabled:"
+	}
+}

--- a/snippets/win_path.json
+++ b/snippets/win_path.json
@@ -1,0 +1,18 @@
+{
+	"win_path.exists": {
+		"body": [
+			"win_path.exists:",
+			"$0"
+		],
+		"prefix": "win_path.exists:",
+		"description": "win_path.exists:"
+	},
+	"win_path.absent": {
+		"body": [
+			"win_path.absent:",
+			"$0"
+		],
+		"prefix": "win_path.absent:",
+		"description": "win_path.absent:"
+	}
+}

--- a/snippets/win_pki.json
+++ b/snippets/win_pki.json
@@ -1,0 +1,18 @@
+{
+	"win_pki.remove_cert": {
+		"body": [
+			"win_pki.remove_cert:",
+			"$0"
+		],
+		"prefix": "win_pki.remove_cert:",
+		"description": "win_pki.remove_cert:"
+	},
+	"win_pki.import_cert": {
+		"body": [
+			"win_pki.import_cert:",
+			"$0"
+		],
+		"prefix": "win_pki.import_cert:",
+		"description": "win_pki.import_cert:"
+	}
+}

--- a/snippets/win_smtp_server.json
+++ b/snippets/win_smtp_server.json
@@ -1,0 +1,34 @@
+{
+	"win_smtp_server.active_log_format": {
+		"body": [
+			"win_smtp_server.active_log_format:",
+			"$0"
+		],
+		"prefix": "win_smtp_server.active_log_format:",
+		"description": "win_smtp_server.active_log_format:"
+	},
+	"win_smtp_server.server_setting": {
+		"body": [
+			"win_smtp_server.server_setting:",
+			"$0"
+		],
+		"prefix": "win_smtp_server.server_setting:",
+		"description": "win_smtp_server.server_setting:"
+	},
+	"win_smtp_server.relay_ip_list": {
+		"body": [
+			"win_smtp_server.relay_ip_list:",
+			"$0"
+		],
+		"prefix": "win_smtp_server.relay_ip_list:",
+		"description": "win_smtp_server.relay_ip_list:"
+	},
+	"win_smtp_server.connection_ip_list": {
+		"body": [
+			"win_smtp_server.connection_ip_list:",
+			"$0"
+		],
+		"prefix": "win_smtp_server.connection_ip_list:",
+		"description": "win_smtp_server.connection_ip_list:"
+	}
+}

--- a/snippets/winrepo.json
+++ b/snippets/winrepo.json
@@ -1,0 +1,19 @@
+{
+	"winrepo state": {
+		"prefix": [
+			"winrepo."
+		],
+		"body": [
+			"winrepo.${1|genrepo|}:"
+		],
+		"description": "winrepo state"
+	},
+	"winrepo.genrepo": {
+		"prefix": "winrepo.genrepo:",
+		"body": [
+			"winrepo.genrepo:",
+			"$0"
+		],
+		"description": "winrepo.genrepo:"
+	}
+}

--- a/snippets/winrepo.json
+++ b/snippets/winrepo.json
@@ -1,13 +1,4 @@
 {
-	"winrepo state": {
-		"prefix": [
-			"winrepo."
-		],
-		"body": [
-			"winrepo.${1|genrepo|}:"
-		],
-		"description": "winrepo state"
-	},
 	"winrepo.genrepo": {
 		"prefix": "winrepo.genrepo:",
 		"body": [

--- a/snippets/wua.json
+++ b/snippets/wua.json
@@ -1,0 +1,26 @@
+{
+	"wua.installed": {
+		"body": [
+			"wua.installed:",
+			"$0"
+		],
+		"prefix": "wua.installed:",
+		"description": "wua.installed:"
+	},
+	"wua.removed": {
+		"body": [
+			"wua.removed:",
+			"$0"
+		],
+		"prefix": "wua.removed:",
+		"description": "wua.removed:"
+	},
+	"wua.uptodate": {
+		"body": [
+			"wua.uptodate:",
+			"$0"
+		],
+		"prefix": "wua.uptodate:",
+		"description": "wua.uptodate:"
+	}
+}

--- a/snippets/wusa.json
+++ b/snippets/wusa.json
@@ -1,0 +1,18 @@
+{
+	"wusa.installed": {
+		"body": [
+			"wusa.installed:",
+			"$0"
+		],
+		"prefix": "wusa.installed:",
+		"description": "wusa.installed:"
+	},
+	"wusa.uninstalled": {
+		"body": [
+			"wusa.uninstalled:",
+			"$0"
+		],
+		"prefix": "wusa.uninstalled:",
+		"description": "wusa.uninstalled:"
+	}
+}

--- a/snippets/xml.json
+++ b/snippets/xml.json
@@ -1,0 +1,19 @@
+{
+	"xml state": {
+		"prefix": [
+			"xml."
+		],
+		"body": [
+			"xml.${1|value_present|}:"
+		],
+		"description": "xml state"
+	},
+	"xml.value_present": {
+		"prefix": "xml.value_present:",
+		"body": [
+			"xml.value_present:",
+			"$0"
+		],
+		"description": "xml.value_present:"
+	}
+}

--- a/snippets/xml.json
+++ b/snippets/xml.json
@@ -1,13 +1,4 @@
 {
-	"xml state": {
-		"prefix": [
-			"xml."
-		],
-		"body": [
-			"xml.${1|value_present|}:"
-		],
-		"description": "xml state"
-	},
 	"xml.value_present": {
 		"prefix": "xml.value_present:",
 		"body": [

--- a/snippets/zabbix_action.json
+++ b/snippets/zabbix_action.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_action state": {
-		"prefix": [
-			"zabbix_action."
-		],
-		"body": [
-			"zabbix_action.${1|absent,present|}:"
-		],
-		"description": "zabbix_action state"
-	},
 	"zabbix_action.absent": {
 		"prefix": "zabbix_action.absent:",
 		"body": [

--- a/snippets/zabbix_action.json
+++ b/snippets/zabbix_action.json
@@ -1,0 +1,27 @@
+{
+	"zabbix_action state": {
+		"prefix": [
+			"zabbix_action."
+		],
+		"body": [
+			"zabbix_action.${1|absent,present|}:"
+		],
+		"description": "zabbix_action state"
+	},
+	"zabbix_action.absent": {
+		"prefix": "zabbix_action.absent:",
+		"body": [
+			"zabbix_action.absent:",
+			"$0"
+		],
+		"description": "zabbix_action.absent:"
+	},
+	"zabbix_action.present": {
+		"prefix": "zabbix_action.present:",
+		"body": [
+			"zabbix_action.present:",
+			"$0"
+		],
+		"description": "zabbix_action.present:"
+	}
+}

--- a/snippets/zabbix_host.json
+++ b/snippets/zabbix_host.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_host state": {
-		"prefix": [
-			"zabbix_host."
-		],
-		"body": [
-			"zabbix_host.${1|absent,assign_templates,deepcopy,present|}:"
-		],
-		"description": "zabbix_host state"
-	},
 	"zabbix_host.absent": {
 		"prefix": "zabbix_host.absent:",
 		"body": [

--- a/snippets/zabbix_host.json
+++ b/snippets/zabbix_host.json
@@ -1,0 +1,43 @@
+{
+	"zabbix_host state": {
+		"prefix": [
+			"zabbix_host."
+		],
+		"body": [
+			"zabbix_host.${1|absent,assign_templates,deepcopy,present|}:"
+		],
+		"description": "zabbix_host state"
+	},
+	"zabbix_host.absent": {
+		"prefix": "zabbix_host.absent:",
+		"body": [
+			"zabbix_host.absent:",
+			"$0"
+		],
+		"description": "zabbix_host.absent:"
+	},
+	"zabbix_host.assign_templates": {
+		"prefix": "zabbix_host.assign_templates:",
+		"body": [
+			"zabbix_host.assign_templates:",
+			"$0"
+		],
+		"description": "zabbix_host.assign_templates:"
+	},
+	"zabbix_host.deepcopy": {
+		"prefix": "zabbix_host.deepcopy:",
+		"body": [
+			"zabbix_host.deepcopy:",
+			"$0"
+		],
+		"description": "zabbix_host.deepcopy:"
+	},
+	"zabbix_host.present": {
+		"prefix": "zabbix_host.present:",
+		"body": [
+			"zabbix_host.present:",
+			"$0"
+		],
+		"description": "zabbix_host.present:"
+	}
+}

--- a/snippets/zabbix_hostgroup.json
+++ b/snippets/zabbix_hostgroup.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_hostgroup state": {
-		"prefix": [
-			"zabbix_hostgroup."
-		],
-		"body": [
-			"zabbix_hostgroup.${1|absent,present|}:"
-		],
-		"description": "zabbix_hostgroup state"
-	},
 	"zabbix_hostgroup.absent": {
 		"prefix": "zabbix_hostgroup.absent:",
 		"body": [

--- a/snippets/zabbix_hostgroup.json
+++ b/snippets/zabbix_hostgroup.json
@@ -1,0 +1,27 @@
+{
+	"zabbix_hostgroup state": {
+		"prefix": [
+			"zabbix_hostgroup."
+		],
+		"body": [
+			"zabbix_hostgroup.${1|absent,present|}:"
+		],
+		"description": "zabbix_hostgroup state"
+	},
+	"zabbix_hostgroup.absent": {
+		"prefix": "zabbix_hostgroup.absent:",
+		"body": [
+			"zabbix_hostgroup.absent:",
+			"$0"
+		],
+		"description": "zabbix_hostgroup.absent:"
+	},
+	"zabbix_hostgroup.present": {
+		"prefix": "zabbix_hostgroup.present:",
+		"body": [
+			"zabbix_hostgroup.present:",
+			"$0"
+		],
+		"description": "zabbix_hostgroup.present:"
+	}
+}

--- a/snippets/zabbix_mediatype.json
+++ b/snippets/zabbix_mediatype.json
@@ -1,0 +1,27 @@
+{
+	"zabbix_mediatype state": {
+		"prefix": [
+			"zabbix_mediatype."
+		],
+		"body": [
+			"zabbix_mediatype.${1|absent,present|}:"
+		],
+		"description": "zabbix_mediatype state"
+	},
+	"zabbix_mediatype.absent": {
+		"prefix": "zabbix_mediatype.absent:",
+		"body": [
+			"zabbix_mediatype.absent:",
+			"$0"
+		],
+		"description": "zabbix_mediatype.absent:"
+	},
+	"zabbix_mediatype.present": {
+		"prefix": "zabbix_mediatype.present:",
+		"body": [
+			"zabbix_mediatype.present:",
+			"$0"
+		],
+		"description": "zabbix_mediatype.present:"
+	}
+}

--- a/snippets/zabbix_mediatype.json
+++ b/snippets/zabbix_mediatype.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_mediatype state": {
-		"prefix": [
-			"zabbix_mediatype."
-		],
-		"body": [
-			"zabbix_mediatype.${1|absent,present|}:"
-		],
-		"description": "zabbix_mediatype state"
-	},
 	"zabbix_mediatype.absent": {
 		"prefix": "zabbix_mediatype.absent:",
 		"body": [

--- a/snippets/zabbix_template.json
+++ b/snippets/zabbix_template.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_template state": {
-		"prefix": [
-			"zabbix_template."
-		],
-		"body": [
-			"zabbix_template.${1|absent,is_present,present|}:"
-		],
-		"description": "zabbix_template state"
-	},
 	"zabbix_template.absent": {
 		"prefix": "zabbix_template.absent:",
 		"body": [

--- a/snippets/zabbix_template.json
+++ b/snippets/zabbix_template.json
@@ -1,0 +1,35 @@
+{
+	"zabbix_template state": {
+		"prefix": [
+			"zabbix_template."
+		],
+		"body": [
+			"zabbix_template.${1|absent,is_present,present|}:"
+		],
+		"description": "zabbix_template state"
+	},
+	"zabbix_template.absent": {
+		"prefix": "zabbix_template.absent:",
+		"body": [
+			"zabbix_template.absent:",
+			"$0"
+		],
+		"description": "zabbix_template.absent:"
+	},
+	"zabbix_template.is_present": {
+		"prefix": "zabbix_template.is_present:",
+		"body": [
+			"zabbix_template.is_present:",
+			"$0"
+		],
+		"description": "zabbix_template.is_present:"
+	},
+	"zabbix_template.present": {
+		"prefix": "zabbix_template.present:",
+		"body": [
+			"zabbix_template.present:",
+			"$0"
+		],
+		"description": "zabbix_template.present:"
+	}
+}

--- a/snippets/zabbix_user.json
+++ b/snippets/zabbix_user.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_user state": {
-		"prefix": [
-			"zabbix_user."
-		],
-		"body": [
-			"zabbix_user.${1|absent,admin_password_present,deepcopy,present|}:"
-		],
-		"description": "zabbix_user state"
-	},
 	"zabbix_user.absent": {
 		"prefix": "zabbix_user.absent:",
 		"body": [

--- a/snippets/zabbix_user.json
+++ b/snippets/zabbix_user.json
@@ -1,0 +1,43 @@
+{
+	"zabbix_user state": {
+		"prefix": [
+			"zabbix_user."
+		],
+		"body": [
+			"zabbix_user.${1|absent,admin_password_present,deepcopy,present|}:"
+		],
+		"description": "zabbix_user state"
+	},
+	"zabbix_user.absent": {
+		"prefix": "zabbix_user.absent:",
+		"body": [
+			"zabbix_user.absent:",
+			"$0"
+		],
+		"description": "zabbix_user.absent:"
+	},
+	"zabbix_user.admin_password_present": {
+		"prefix": "zabbix_user.admin_password_present:",
+		"body": [
+			"zabbix_user.admin_password_present:",
+			"$0"
+		],
+		"description": "zabbix_user.admin_password_present:"
+	},
+	"zabbix_user.deepcopy": {
+		"prefix": "zabbix_user.deepcopy:",
+		"body": [
+			"zabbix_user.deepcopy:",
+			"$0"
+		],
+		"description": "zabbix_user.deepcopy:"
+	},
+	"zabbix_user.present": {
+		"prefix": "zabbix_user.present:",
+		"body": [
+			"zabbix_user.present:",
+			"$0"
+		],
+		"description": "zabbix_user.present:"
+	}
+}

--- a/snippets/zabbix_usergroup.json
+++ b/snippets/zabbix_usergroup.json
@@ -1,0 +1,27 @@
+{
+	"zabbix_usergroup state": {
+		"prefix": [
+			"zabbix_usergroup."
+		],
+		"body": [
+			"zabbix_usergroup.${1|absent,present|}:"
+		],
+		"description": "zabbix_usergroup state"
+	},
+	"zabbix_usergroup.absent": {
+		"prefix": "zabbix_usergroup.absent:",
+		"body": [
+			"zabbix_usergroup.absent:",
+			"$0"
+		],
+		"description": "zabbix_usergroup.absent:"
+	},
+	"zabbix_usergroup.present": {
+		"prefix": "zabbix_usergroup.present:",
+		"body": [
+			"zabbix_usergroup.present:",
+			"$0"
+		],
+		"description": "zabbix_usergroup.present:"
+	}
+}

--- a/snippets/zabbix_usergroup.json
+++ b/snippets/zabbix_usergroup.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_usergroup state": {
-		"prefix": [
-			"zabbix_usergroup."
-		],
-		"body": [
-			"zabbix_usergroup.${1|absent,present|}:"
-		],
-		"description": "zabbix_usergroup state"
-	},
 	"zabbix_usergroup.absent": {
 		"prefix": "zabbix_usergroup.absent:",
 		"body": [

--- a/snippets/zabbix_usermacro.json
+++ b/snippets/zabbix_usermacro.json
@@ -1,0 +1,27 @@
+{
+	"zabbix_usermacro state": {
+		"prefix": [
+			"zabbix_usermacro."
+		],
+		"body": [
+			"zabbix_usermacro.${1|absent,present|}:"
+		],
+		"description": "zabbix_usermacro state"
+	},
+	"zabbix_usermacro.absent": {
+		"prefix": "zabbix_usermacro.absent:",
+		"body": [
+			"zabbix_usermacro.absent:",
+			"$0"
+		],
+		"description": "zabbix_usermacro.absent:"
+	},
+	"zabbix_usermacro.present": {
+		"prefix": "zabbix_usermacro.present:",
+		"body": [
+			"zabbix_usermacro.present:",
+			"$0"
+		],
+		"description": "zabbix_usermacro.present:"
+	}
+}

--- a/snippets/zabbix_usermacro.json
+++ b/snippets/zabbix_usermacro.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_usermacro state": {
-		"prefix": [
-			"zabbix_usermacro."
-		],
-		"body": [
-			"zabbix_usermacro.${1|absent,present|}:"
-		],
-		"description": "zabbix_usermacro state"
-	},
 	"zabbix_usermacro.absent": {
 		"prefix": "zabbix_usermacro.absent:",
 		"body": [

--- a/snippets/zabbix_valuemap.json
+++ b/snippets/zabbix_valuemap.json
@@ -1,0 +1,27 @@
+{
+	"zabbix_valuemap state": {
+		"prefix": [
+			"zabbix_valuemap."
+		],
+		"body": [
+			"zabbix_valuemap.${1|absent,present|}:"
+		],
+		"description": "zabbix_valuemap state"
+	},
+	"zabbix_valuemap.absent": {
+		"prefix": "zabbix_valuemap.absent:",
+		"body": [
+			"zabbix_valuemap.absent:",
+			"$0"
+		],
+		"description": "zabbix_valuemap.absent:"
+	},
+	"zabbix_valuemap.present": {
+		"prefix": "zabbix_valuemap.present:",
+		"body": [
+			"zabbix_valuemap.present:",
+			"$0"
+		],
+		"description": "zabbix_valuemap.present:"
+	}
+}

--- a/snippets/zabbix_valuemap.json
+++ b/snippets/zabbix_valuemap.json
@@ -1,13 +1,4 @@
 {
-	"zabbix_valuemap state": {
-		"prefix": [
-			"zabbix_valuemap."
-		],
-		"body": [
-			"zabbix_valuemap.${1|absent,present|}:"
-		],
-		"description": "zabbix_valuemap state"
-	},
 	"zabbix_valuemap.absent": {
 		"prefix": "zabbix_valuemap.absent:",
 		"body": [

--- a/snippets/zenoss.json
+++ b/snippets/zenoss.json
@@ -1,13 +1,4 @@
 {
-	"zenoss state": {
-		"prefix": [
-			"zenoss."
-		],
-		"body": [
-			"zenoss.${1|monitored|}:"
-		],
-		"description": "zenoss state"
-	},
 	"zenoss.monitored": {
 		"prefix": "zenoss.monitored:",
 		"body": [

--- a/snippets/zenoss.json
+++ b/snippets/zenoss.json
@@ -1,0 +1,19 @@
+{
+	"zenoss state": {
+		"prefix": [
+			"zenoss."
+		],
+		"body": [
+			"zenoss.${1|monitored|}:"
+		],
+		"description": "zenoss state"
+	},
+	"zenoss.monitored": {
+		"prefix": "zenoss.monitored:",
+		"body": [
+			"zenoss.monitored:",
+			"$0"
+		],
+		"description": "zenoss.monitored:"
+	}
+}


### PR DESCRIPTION
Here's some initial work to support state module autocompletion in sls files. 
Fixes: #2

A python generate script creates basic snippet json files for each salt state's functions. Since the arguments for each function are highly variable, these autogenerated functions only complete the name, and move the cursor to the next line. But the json files can be further updated by hand to include more function specific defaults where they make sense. 

I've added basic arguments for the functions in the test state as an example. 

Usage is as follows:
![image](https://user-images.githubusercontent.com/1360357/79201170-8f3e2a00-7e2f-11ea-92b3-2322bc1339f0.png)
Typing `test.` and pressing ctrl-space brings up the menu for the test state. 

Selecting the first `test.` entry prompts for a specific function:
![image](https://user-images.githubusercontent.com/1360357/79201290-bf85c880-7e2f-11ea-93f3-a03a02f40a72.png)
Pressing tab will complete the snippet prompting and move the cursor to the end of the line. 

Pressing ctrl-space again, will pickup the full function definition, and add additional attributes:
![image](https://user-images.githubusercontent.com/1360357/79201449-0247a080-7e30-11ea-98e7-962e85f4efdf.png)
![image](https://user-images.githubusercontent.com/1360357/79201497-0ffd2600-7e30-11ea-8fe0-f7ddea75b616.png)
Again, any default entries which require filling out, are cycled through with the tab key. After all entries have been filled out, the cursor is again brought to the end of the input. 

VSCode will offer all matching state options, ~so you can also skip the first prompting step~ and simply select the specific function from the initial prompt. The basic initial selector has since been removed in favor of using the full function lists.

~So far only~ the test state has been configured besides the basic listing, but it's a start and can as fancy as people want. 
![image](https://user-images.githubusercontent.com/1360357/79202122-09bb7980-7e31-11ea-8c59-6ccb88d08216.png)

Human edited snippets:

- test
- saltcheck tests (.tst files)
- file
- cron
- docker_container
- docker_image
- host
- http
- keystore

 