### PR TITLE
Fix VSCode language ID for sls files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,21 +30,11 @@
 				"aliases": [
 					"SaltStack",
 					"salt",
+					"saltcheck",
 					"pillar"
 				],
 				"extensions": [
-					".sls"
-				],
-				"configuration": "./jinja.configuration.json"
-			},
-			{
-				"id": "tst",
-				"aliases": [
-					"SaltStack",
-					"salt",
-					"saltcheck"
-				],
-				"extensions": [
+					".sls",
 					".tst"
 				],
 				"configuration": "./jinja.configuration.json"


### PR DESCRIPTION
Fix VSCode language ID for `.sls` files by combining the `.tst` and `.sls` extensions into a single VSCode language entry.

Fixes: #12
Fixes: warpnet/vscode-salt-lint#10